### PR TITLE
Fix for report filtering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     compile 'org.codehaus.janino:janino:3.0.8'
     compile 'org.projectlombok:lombok:1.18.4'
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.8.8'
+    compile 'org.apache.commons:commons-collections4:4.1'
 
     compile 'mysql:mysql-connector-java:8.0.20'
     compile 'com.h2database:h2:1.4.197'

--- a/src/main/java/uk/gov/cshr/report/controller/BookingController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/BookingController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.cshr.report.reports.BookingReportRow;
 import uk.gov.cshr.report.service.ReportService;
+import uk.gov.cshr.report.validators.ReportRoleValidator;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -26,10 +27,9 @@ public class BookingController {
     @GetMapping(produces = "application/csv; charset=utf-8", params = {"from", "to"})
     public ResponseEntity<List<BookingReportRow>> generateBookingReport(
             @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
-            @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to, Authentication authentication
-    ) {
-        boolean isProfessionReporter = authentication.getAuthorities().contains(new SimpleGrantedAuthority("PROFESSION_REPORTER"));
-        List<BookingReportRow> bookingReport = reportService.buildBookingReport(from, to, isProfessionReporter);
+            @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to, Authentication authentication) {
+        ReportRoleValidator.validate(authentication.getAuthorities());
+        List<BookingReportRow> bookingReport = reportService.buildBookingReport(from, to, authentication);
         return ResponseEntity.ok(bookingReport);
     }
 }

--- a/src/main/java/uk/gov/cshr/report/controller/ModuleController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/ModuleController.java
@@ -1,18 +1,21 @@
 package uk.gov.cshr.report.controller;
 
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+
+import uk.gov.cshr.report.reports.ModuleReportRow;
+import uk.gov.cshr.report.service.ReportService;
+import uk.gov.cshr.report.validators.ReportRoleValidator;
+
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.cshr.report.reports.ModuleReportRow;
-import uk.gov.cshr.report.service.ReportService;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequestMapping("/modules")
@@ -28,10 +31,9 @@ public class ModuleController {
     public ResponseEntity<List<ModuleReportRow>> generateModuleReport(
             @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
-            Authentication authentication
-    ) {
-        boolean isProfessionReporter = authentication.getAuthorities().contains(new SimpleGrantedAuthority("PROFESSION_REPORTER"));
-        List<ModuleReportRow> report = reportService.buildModuleReport(from, to, isProfessionReporter);
+            Authentication authentication) {
+        ReportRoleValidator.validate(authentication.getAuthorities());
+        List<ModuleReportRow> report = reportService.buildModuleReport(from, to, authentication);
 
         return ResponseEntity.ok(report);
     }

--- a/src/main/java/uk/gov/cshr/report/domain/registry/CivilServant.java
+++ b/src/main/java/uk/gov/cshr/report/domain/registry/CivilServant.java
@@ -8,6 +8,7 @@ public class CivilServant {
     private String uid;
     private String name;
     private String organisation;
+    private String organizationUnit;
     private String profession;
     private String otherAreasOfWork;
     private String grade;

--- a/src/main/java/uk/gov/cshr/report/enums/ReporterRole.java
+++ b/src/main/java/uk/gov/cshr/report/enums/ReporterRole.java
@@ -1,0 +1,17 @@
+package uk.gov.cshr.report.enums;
+
+public enum ReporterRole {
+    ORGANIZATION_REPORTER("ORGANISATION_REPORTER"),
+    PROFESSION_REPORTER("PROFESSION_REPORTER"),
+    CSHR_REPORTER("CSHR_REPORTER");
+
+    private final String value;
+
+    ReporterRole(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/cshr/report/exception/UserNotFoundException.java
+++ b/src/main/java/uk/gov/cshr/report/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package uk.gov.cshr.report.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String userId) {
+        super(String.format("User not found: %s", userId));
+    }
+}

--- a/src/main/java/uk/gov/cshr/report/factory/QueryResultExtractor.java
+++ b/src/main/java/uk/gov/cshr/report/factory/QueryResultExtractor.java
@@ -2,6 +2,7 @@ package uk.gov.cshr.report.factory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 
 import uk.gov.cshr.report.domain.identity.Identity;
 import uk.gov.cshr.report.domain.learnerrecord.Booking;
@@ -18,8 +19,16 @@ public class QueryResultExtractor {
         moduleRecord.setModuleId(rs.getString(1));
         moduleRecord.setState(rs.getString(2));
         moduleRecord.setLearner(rs.getString(3));
-        moduleRecord.setStateChangeDate(rs.getString(4));
-        moduleRecord.setCompletedAt(rs.getString(5));
+
+        Object updateDate = rs.getObject(4);
+        if (updateDate != null) {
+            moduleRecord.setStateChangeDate(((Timestamp) updateDate).toLocalDateTime().toString());
+        }
+
+        Object completedDate = rs.getObject(5);
+        if (completedDate != null) {
+            moduleRecord.setCompletedAt(((Timestamp) completedDate).toLocalDateTime().toString());
+        }
 
         return moduleRecord;
     }
@@ -58,6 +67,14 @@ public class QueryResultExtractor {
         civilServant.setUid(rs.getString(5));
         civilServant.setGrade(rs.getString(6));
         civilServant.setOtherAreasOfWork(rs.getString(7));
+
+        return civilServant;
+    }
+
+    public static CivilServant extractCivilServantForOrganisationUnit(ResultSet rs) throws SQLException {
+        CivilServant civilServant = new CivilServant();
+        civilServant.setOrganizationUnit(rs.getString(1));
+        civilServant.setProfession(rs.getString(2));
 
         return civilServant;
     }

--- a/src/main/java/uk/gov/cshr/report/repository/DbRepository.java
+++ b/src/main/java/uk/gov/cshr/report/repository/DbRepository.java
@@ -23,12 +23,12 @@ import org.springframework.stereotype.Repository;
 public class DbRepository {
     private static final String GET_MODULE_RECORDS = "SELECT mr.module_id, mr.state, cr.user_id, mr.updated_at, mr.completion_date FROM module_record mr " +
         "LEFT OUTER JOIN learner_record.course_record cr on ((cr.course_id, cr.user_id) = (mr.course_id, mr.user_id)) " +
-        "WHERE (mr.updated_at BETWEEN ? AND ?) AND (EXISTS (select mr.course_id, mr.user_id FROM course_record cr2 where mr.course_id = cr2.course_id and mr.user_id = cr2.user_id))";
+        "WHERE (mr.updated_at >= ? AND mr.updated_at <= ?) AND (EXISTS (select mr.course_id, mr.user_id FROM course_record cr2 where mr.course_id = cr2.course_id and mr.user_id = cr2.user_id))";
     private static final String GET_BOOKINGS = "SELECT b.id, b.accessibility_options, b.booking_time, b.cancellation_reason, b.cancellation_time, b.confirmation_time, e.uid, l.uid, b.po_number, b.status, b.booking_reference " +
         "FROM learner_record.booking b " +
         "LEFT OUTER JOIN learner_record.learner l ON l.id = b.learner_id " +
         "LEFT OUTER JOIN learner_record.event e ON e.id = b.event_id " +
-        "WHERE b.booking_time BETWEEN ? AND ?";
+        "WHERE b.booking_time >= ? AND b.booking_time <= ? ";
     private static final String GET_IDENTITIES = "SELECT i.email, i.uid " +
         "FROM identity.identity i";
     private static final String GET_CIVIL_SERVANT_BY_USER_ID = "select cr.organisational_unit_id, cr.profession_id " +
@@ -70,11 +70,11 @@ public class DbRepository {
     }
 
     public List<ModuleRecord> getModuleRecords(LocalDate from, LocalDate to) {
-        return jdbcTemplate.query(GET_MODULE_RECORDS, (rs, rowNum) -> QueryResultExtractor.extractModuleRecord(rs), from, to.plusDays(1));
+        return jdbcTemplate.query(GET_MODULE_RECORDS, (rs, rowNum) -> QueryResultExtractor.extractModuleRecord(rs), from, to);
     }
 
     public List<Booking> getBookings(LocalDate from, LocalDate to) {
-        return jdbcTemplate.query(GET_BOOKINGS, (rs, rowNum) -> QueryResultExtractor.extractBooking(rs), from, to.plusDays(1));
+        return jdbcTemplate.query(GET_BOOKINGS, (rs, rowNum) -> QueryResultExtractor.extractBooking(rs), from, to);
     }
 
     @PreAuthorize("hasAnyAuthority('DOWNLOAD_BOOKING_FEED')")

--- a/src/main/java/uk/gov/cshr/report/repository/DbRepository.java
+++ b/src/main/java/uk/gov/cshr/report/repository/DbRepository.java
@@ -11,10 +11,12 @@ import uk.gov.cshr.report.domain.identity.Identity;
 import uk.gov.cshr.report.domain.learnerrecord.Booking;
 import uk.gov.cshr.report.domain.learnerrecord.ModuleRecord;
 import uk.gov.cshr.report.domain.registry.CivilServant;
+import uk.gov.cshr.report.exception.UserNotFoundException;
 import uk.gov.cshr.report.factory.QueryResultExtractor;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -29,7 +31,29 @@ public class DbRepository {
         "WHERE b.booking_time BETWEEN ? AND ?";
     private static final String GET_IDENTITIES = "SELECT i.email, i.uid " +
         "FROM identity.identity i";
-    private static final String GET_CIVIL_SERVANTS = "SELECT cr.id, cr.full_name, o.name, p.name, i.uid, g.name, group_concat(p2.name) " +
+    private static final String GET_CIVIL_SERVANT_BY_USER_ID = "select cr.organisational_unit_id, cr.profession_id " +
+        "FROM csrs.civil_servant cr " +
+        "CROSS JOIN csrs.identity i " +
+        "WHERE cr.identity_id = i.id AND i.uid = ?";
+    private static final String GET_ALL_CIVIL_SERVANTS_BY_ORGANISATION = "SELECT cr.id, cr.full_name, org.name, p1.name, i.uid, g.name, group_concat(p2.name) FROM csrs.civil_servant cr " +
+        "INNER JOIN csrs.civil_servant_other_areas_of_work oaw on cr.id = oaw.civil_servant_id " +
+        "INNER JOIN csrs.profession p2 on oaw.other_areas_of_work_id = p2.id " +
+        "LEFT OUTER JOIN csrs.organisational_unit org on (org.id = cr.organisational_unit_id) " +
+        "LEFT OUTER JOIN csrs.profession p1 on (p1.id = cr.profession_id) " +
+        "LEFT OUTER JOIN csrs.identity i on (i.id = cr.identity_id) " +
+        "LEFT OUTER JOIN csrs.grade g on (g.id = cr.grade_id) " +
+        "WHERE org.id = ? " +
+        "GROUP by cr.id";
+    private static final String GET_ALL_CIVIL_SERVANTS_BY_PROFESSION = "SELECT cr.id, cr.full_name, org.name, p1.name, i.uid, g.name, group_concat(p2.name) FROM csrs.civil_servant cr " +
+        "INNER JOIN csrs.civil_servant_other_areas_of_work oaw on cr.id = oaw.civil_servant_id " +
+        "INNER JOIN csrs.profession p2 on oaw.other_areas_of_work_id = p2.id " +
+        "LEFT OUTER JOIN csrs.organisational_unit org on (org.id = cr.organisational_unit_id) " +
+        "LEFT OUTER JOIN csrs.profession p1 on (p1.id = cr.profession_id) " +
+        "LEFT OUTER JOIN csrs.identity i on (i.id = cr.identity_id) " +
+        "LEFT OUTER JOIN csrs.grade g on (g.id = cr.grade_id) " +
+        "WHERE p1.id = ? " +
+        "GROUP BY cr.id";
+    private static final String GET_ALL_CIVIL_SERVANTS = "SELECT cr.id, cr.full_name, o.name, p.name, i.uid, g.name, group_concat(p2.name) " +
         "FROM csrs.civil_servant cr " +
         "INNER JOIN csrs.civil_servant_other_areas_of_work omw on cr.id = omw.civil_servant_id " +
         "INNER JOIN csrs.profession p2 on omw.other_areas_of_work_id = p2.id " +
@@ -53,13 +77,33 @@ public class DbRepository {
         return jdbcTemplate.query(GET_BOOKINGS, (rs, rowNum) -> QueryResultExtractor.extractBooking(rs), from, to.plusDays(1));
     }
 
+    @PreAuthorize("hasAnyAuthority('DOWNLOAD_BOOKING_FEED')")
     public Map<String, Identity> getIdentitiesMap() {
         return jdbcTemplate.query(GET_IDENTITIES, (rs, rowNum) -> QueryResultExtractor.extractIdentity(rs)).stream()
             .collect(Collectors.toMap(Identity::getUid, identity -> identity));
     }
 
-    public Map<String, CivilServant> getCivilServantMap() {
-        return jdbcTemplate.query(GET_CIVIL_SERVANTS, (rs, rowNum) -> QueryResultExtractor.extractCivilServant(rs)).stream()
+    public Map<String, CivilServant> getAllCivilServantsByOrganisation(String userId) {
+        return jdbcTemplate.query(GET_ALL_CIVIL_SERVANTS_BY_ORGANISATION, (rs, rowNum) -> QueryResultExtractor.extractCivilServant(rs), getCivilServantUserByUserId(userId).getOrganizationUnit()).stream()
             .collect(Collectors.toMap(CivilServant::getUid, civilServant -> civilServant));
+    }
+
+    public Map<String, CivilServant> getAllCivilServantsByProfession(String userId) {
+        return jdbcTemplate.query(GET_ALL_CIVIL_SERVANTS_BY_PROFESSION, (rs, rowNum) -> QueryResultExtractor.extractCivilServant(rs), getCivilServantUserByUserId(userId).getProfession()).stream()
+            .collect(Collectors.toMap(CivilServant::getUid, civilServant -> civilServant));
+    }
+
+    public Map<String, CivilServant> getAllCivilServants() {
+        return jdbcTemplate.query(GET_ALL_CIVIL_SERVANTS, (rs, rowNum) -> QueryResultExtractor.extractCivilServant(rs)).stream()
+            .collect(Collectors.toMap(CivilServant::getUid, civilServant -> civilServant));
+    }
+
+    private CivilServant getCivilServantUserByUserId(String userId) {
+        List<CivilServant> civilServantUser = jdbcTemplate.query(GET_CIVIL_SERVANT_BY_USER_ID, (rs, rowNum) -> QueryResultExtractor.extractCivilServantForOrganisationUnit(rs), userId);
+        if (civilServantUser.isEmpty()) {
+            throw new UserNotFoundException(userId);
+        }
+
+        return civilServantUser.get(0);
     }
 }

--- a/src/main/java/uk/gov/cshr/report/service/ReportService.java
+++ b/src/main/java/uk/gov/cshr/report/service/ReportService.java
@@ -3,6 +3,7 @@ package uk.gov.cshr.report.service;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,12 +14,16 @@ import uk.gov.cshr.report.domain.identity.Identity;
 import uk.gov.cshr.report.domain.learnerrecord.Booking;
 import uk.gov.cshr.report.domain.learnerrecord.ModuleRecord;
 import uk.gov.cshr.report.domain.registry.CivilServant;
+import uk.gov.cshr.report.enums.ReporterRole;
 import uk.gov.cshr.report.factory.ReportRowFactory;
 import uk.gov.cshr.report.reports.BookingReportRow;
 import uk.gov.cshr.report.reports.ModuleReportRow;
 import uk.gov.cshr.report.repository.DbRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -36,11 +41,11 @@ public class ReportService {
         this.dbRepository = dbRepository;
     }
 
-    public List<BookingReportRow> buildBookingReport(LocalDate from, LocalDate to, boolean isProfessionReporter) {
+    public List<BookingReportRow> buildBookingReport(LocalDate from, LocalDate to, Authentication authentication) {
         List<BookingReportRow> report = new ArrayList<>();
 
         List<Booking> bookings = dbRepository.getBookings(from, to);
-        Map<String, CivilServant> civilServantMap = dbRepository.getCivilServantMap();
+        Map<String, CivilServant> civilServantMap = fetchCivilServants(authentication);
         Map<String, Event> eventMap = learningCatalogueService.getEventMap();
         Map<String, Identity> identitiesMap = dbRepository.getIdentitiesMap();
 
@@ -52,7 +57,7 @@ public class ReportService {
                 if (eventMap.containsKey(eventUid)) {
                     Optional<CivilServant> civilServant = Optional.ofNullable(civilServantMap.get(booking.getLearner()));
                     Optional<Event> event = Optional.ofNullable(eventMap.get(eventUid));
-                    report.add(reportRowFactory.createBookingReportRow(civilServant, event, booking, identity, isProfessionReporter));
+                    report.add(reportRowFactory.createBookingReportRow(civilServant, event, booking, identity, isProfessionReporter(authentication)));
                 }
             }
         }
@@ -60,11 +65,11 @@ public class ReportService {
         return report;
     }
 
-    public List<ModuleReportRow> buildModuleReport(LocalDate from, LocalDate to, boolean isProfessionReporter) {
+    public List<ModuleReportRow> buildModuleReport(LocalDate from, LocalDate to, Authentication authentication) {
         List<ModuleReportRow> report = new ArrayList<>();
         Map<String, Identity> identitiesMap = dbRepository.getIdentitiesMap();
         List<ModuleRecord> moduleRecords = dbRepository.getModuleRecords(from, to);
-        Map<String, CivilServant> civilServantMap = dbRepository.getCivilServantMap();
+        Map<String, CivilServant> civilServantMap = fetchCivilServants(authentication);
         Map<String, Module> moduleMap = learningCatalogueService.getModuleMap();
 
         for (ModuleRecord moduleRecord : moduleRecords) {
@@ -76,12 +81,29 @@ public class ReportService {
                 if (moduleMap.containsKey(moduleRecord.getModuleId())) {
                     Module module = moduleMap.get(moduleRecord.getModuleId());
                     if (module != null && identity != null && civilServant != null) {
-                        report.add(reportRowFactory.createModuleReportRow(civilServant, module, moduleRecord, identity, isProfessionReporter));
+                        report.add(reportRowFactory.createModuleReportRow(civilServant, module, moduleRecord, identity, isProfessionReporter(authentication)));
                     }
                 }
             }
         }
 
         return report;
+    }
+
+    private Map<String, CivilServant> fetchCivilServants(Authentication authentication) {
+        Collection<? extends GrantedAuthority> authorities =  authentication.getAuthorities();
+        if (authorities.contains(new SimpleGrantedAuthority(ReporterRole.ORGANIZATION_REPORTER.getValue()))) {
+            return dbRepository.getAllCivilServantsByOrganisation((String) authentication.getPrincipal());
+        } else if (authorities.contains(new SimpleGrantedAuthority(ReporterRole.PROFESSION_REPORTER.getValue()))) {
+            return dbRepository.getAllCivilServantsByProfession((String) authentication.getPrincipal());
+        } else if (authorities.contains(new SimpleGrantedAuthority(ReporterRole.CSHR_REPORTER.getValue()))) {
+            return dbRepository.getAllCivilServants();
+        }
+
+        throw new IllegalArgumentException("No valid report roles present.");
+    }
+
+    private boolean isProfessionReporter(Authentication authentication) {
+        return authentication.getAuthorities().contains(new SimpleGrantedAuthority(ReporterRole.PROFESSION_REPORTER.getValue()));
     }
 }

--- a/src/main/java/uk/gov/cshr/report/validators/ReportRoleValidator.java
+++ b/src/main/java/uk/gov/cshr/report/validators/ReportRoleValidator.java
@@ -1,0 +1,33 @@
+package uk.gov.cshr.report.validators;
+
+import java.util.Collection;
+import java.util.List;
+
+import uk.gov.cshr.report.enums.ReporterRole;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import com.google.common.collect.ImmutableList;
+
+public class ReportRoleValidator {
+    private static final List<SimpleGrantedAuthority> ACCEPTABLE_ROLES = ImmutableList.of(
+        new SimpleGrantedAuthority(ReporterRole.ORGANIZATION_REPORTER.getValue()),
+        new SimpleGrantedAuthority(ReporterRole.PROFESSION_REPORTER.getValue()),
+        new SimpleGrantedAuthority(ReporterRole.CSHR_REPORTER.getValue())
+    );
+
+    private ReportRoleValidator() {
+    }
+
+    public static void validate(Collection<? extends GrantedAuthority> authorities) {
+        if (!CollectionUtils.containsAny(authorities, ACCEPTABLE_ROLES)) {
+            throw new IllegalStateException("No acceptable report generation roles present.");
+        }
+
+        if (CollectionUtils.intersection(authorities, ACCEPTABLE_ROLES).size() > 1) {
+            throw new IllegalStateException("Too many report generation roles assigned to user.");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   jackson:
     serialization:

--- a/src/test/java/uk/gov/cshr/report/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/BookingControllerTest.java
@@ -1,5 +1,21 @@
 package uk.gov.cshr.report.controller;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import uk.gov.cshr.report.reports.BookingReportRow;
+import uk.gov.cshr.report.service.ReportService;
+
 import org.assertj.core.util.Lists;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,19 +25,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.cshr.report.reports.BookingReportRow;
-import uk.gov.cshr.report.service.ReportService;
-
-import java.time.LocalDate;
-import java.util.List;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BookingController.class)
 @RunWith(SpringRunner.class)
@@ -35,7 +38,7 @@ public class BookingControllerTest {
     private ReportService reportService;
 
     @Test
-    @WithMockUser(username = "user", authorities = {"PROFESSION_AUTHOR"})
+    @WithMockUser(username = "user", authorities = {"PROFESSION_REPORTER"})
     public void shouldReturnBookingReport() throws Exception {
         BookingReportRow reportRow = new BookingReportRow();
         reportRow.setStatus("Confirmed");
@@ -59,7 +62,7 @@ public class BookingControllerTest {
         LocalDate from = LocalDate.parse("2018-01-01");
         LocalDate to = LocalDate.parse("2018-01-31");
 
-        when(reportService.buildBookingReport(from, to, false)).thenReturn(report);
+        when(reportService.buildBookingReport(eq(from), eq(to), any())).thenReturn(report);
 
         mockMvc.perform(
                 get("/bookings")

--- a/src/test/java/uk/gov/cshr/report/controller/ModuleControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/ModuleControllerTest.java
@@ -1,5 +1,21 @@
 package uk.gov.cshr.report.controller;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import uk.gov.cshr.report.reports.ModuleReportRow;
+import uk.gov.cshr.report.service.ReportService;
+
 import org.assertj.core.util.Lists;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,22 +25,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.cshr.report.reports.ModuleReportRow;
-import uk.gov.cshr.report.service.ReportService;
-
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ModuleController.class)
 @RunWith(SpringRunner.class)
@@ -37,7 +37,7 @@ public class ModuleControllerTest {
     private ReportService reportService;
 
     @Test
-    @WithMockUser(username = "user", authorities = {"PROFESSION_AUTHOR"})
+    @WithMockUser(username = "user", authorities = {"PROFESSION_REPORTER"})
     public void shouldReturnBookingReport() throws Exception {
         ModuleReportRow reportRow = new ModuleReportRow();
         reportRow.setStatus("Confirmed");
@@ -62,7 +62,7 @@ public class ModuleControllerTest {
         LocalDate from = LocalDate.now().minusDays(7);
         LocalDate to = LocalDate.now();
 
-        when(reportService.buildModuleReport(any(), any(), anyBoolean())).thenReturn(report);
+        when(reportService.buildModuleReport(any(), any(), any())).thenReturn(report);
 
         mockMvc.perform(
                 get("/modules")

--- a/src/test/java/uk/gov/cshr/report/factory/ReportRowFactoryTest.java
+++ b/src/test/java/uk/gov/cshr/report/factory/ReportRowFactoryTest.java
@@ -96,7 +96,7 @@ public class ReportRowFactoryTest {
     }
 
     @Test
-    @WithMockUser(username = "user", authorities = {"PROFESSION_AUTHOR"})
+    @WithMockUser(username = "user", authorities = {"PROFESSION_REPORTER"})
     public void shouldReturnBookingReportRowWithoutLearningProvider() {
         BookingStatus status = BookingStatus.CONFIRMED;
         String learnerUid = "learner-uid";


### PR DESCRIPTION
**Civil Servant Registry Service** maps **report endpoints** according to assigned **reporter roles**. If none of the roles are assigned a "forbidden" response is returned by **CSRS** resulting in failed report generation. If more than one **reporter role** is assigned a mapping error occurs since **CSRS** is not able to determine which endpoint should be used. This logic has been implemented within the reporting service. In addition new **CSRS** direct database fetch queries were implemented.