### PR TITLE
LC 2715 reporting graph

### DIFF
--- a/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
@@ -27,7 +27,7 @@ public class CourseCompletionsController {
 
     @PostMapping("/aggregations/by-course")
     @ResponseBody
-    public AggregationResponse<CourseCompletionAggregation> getCompletionAggregationsByCourse(@Valid @RequestBody GetCourseCompletionsParams params) {
+    public AggregationResponse<CourseCompletionAggregation> getCompletionAggregationsByCourse(@RequestBody @Valid GetCourseCompletionsParams params) {
         List<CourseCompletionAggregation> results =  courseCompletionService.getCourseCompletions(params);
         return new AggregationResponse<>(params.getBinDelimiter().getVal(), results);
     }

--- a/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
@@ -3,7 +3,8 @@ package uk.gov.cshr.report.controller;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import uk.gov.cshr.report.controller.model.AggregationResponse;
@@ -24,9 +25,9 @@ public class CourseCompletionsController {
         this.courseCompletionService = courseCompletionService;
     }
 
-    @GetMapping("/aggregations/by-course")
+    @PostMapping("/aggregations/by-course")
     @ResponseBody
-    public AggregationResponse<CourseCompletionAggregation> getCompletionAggregationsByCourse(@Valid GetCourseCompletionsParams params) {
+    public AggregationResponse<CourseCompletionAggregation> getCompletionAggregationsByCourse(@Valid @RequestBody GetCourseCompletionsParams params) {
         List<CourseCompletionAggregation> results =  courseCompletionService.getCourseCompletions(params);
         return new AggregationResponse<>(params.getBinDelimiter().getVal(), results);
     }

--- a/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
@@ -28,7 +28,7 @@ public class GetCourseCompletionsParams {
     @NotNull
     private List<String> courseIds;
 
-    @Size(min = 1)
+    @Size(min = 1, max = 400)
     @NotNull
     private List<Integer> organisationIds;
 

--- a/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
@@ -7,6 +7,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -15,12 +17,12 @@ import java.util.List;
 @NoArgsConstructor
 public class GetCourseCompletionsParams {
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZ")
-    private ZonedDateTime startDate;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
 
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZ")
-    private ZonedDateTime endDate;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
 
     @Size(min = 1, max = 30)
     @NotNull
@@ -35,4 +37,12 @@ public class GetCourseCompletionsParams {
     private List<Integer> gradeIds;
 
     private AggregationBinDelimiter binDelimiter = AggregationBinDelimiter.DAY;
+
+    public ZonedDateTime getStartDateTime() {
+        return startDate.atStartOfDay(ZoneId.of("UTC"));
+    }
+
+    public ZonedDateTime getEndDateTime() {
+        return endDate.atStartOfDay(ZoneId.of("UTC"));
+    }
 }

--- a/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
@@ -22,7 +22,7 @@ public class GetCourseCompletionsParams {
     @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZ")
     private ZonedDateTime endDate;
 
-    @Size(min = 1, max = 10)
+    @Size(min = 1, max = 30)
     @NotNull
     private List<String> courseIds;
 

--- a/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
@@ -7,8 +7,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -17,12 +15,12 @@ import java.util.List;
 @NoArgsConstructor
 public class GetCourseCompletionsParams {
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private LocalDate startDate;
+    @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZ")
+    private ZonedDateTime startDate;
 
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private LocalDate endDate;
+    @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZ")
+    private ZonedDateTime endDate;
 
     @Size(min = 1, max = 10)
     @NotNull
@@ -37,12 +35,4 @@ public class GetCourseCompletionsParams {
     private List<Integer> gradeIds;
 
     private AggregationBinDelimiter binDelimiter = AggregationBinDelimiter.DAY;
-
-    public ZonedDateTime getStartDate() {
-        return startDate.atStartOfDay(ZoneId.systemDefault());
-    }
-
-    public ZonedDateTime getEndDate() {
-        return endDate.atStartOfDay(ZoneId.systemDefault());
-    }
 }

--- a/src/main/java/uk/gov/cshr/report/service/CourseCompletionService.java
+++ b/src/main/java/uk/gov/cshr/report/service/CourseCompletionService.java
@@ -20,7 +20,7 @@ public class CourseCompletionService {
     }
 
     public List<CourseCompletionAggregation> getCourseCompletions(GetCourseCompletionsParams params) {
-        return repository.getCompletionsAggregationByCourse(params.getBinDelimiter().getVal(), params.getStartDate(), params.getEndDate(),
+        return repository.getCompletionsAggregationByCourse(params.getBinDelimiter().getVal(), params.getStartDateTime(), params.getEndDateTime(),
                 params.getCourseIds(), params.getOrganisationIds(), params.getGradeIds(), params.getProfessionIds());
     }
 

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -5,28 +5,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cshr.report.controller.model.ErrorDtoFactory;
-import uk.gov.cshr.report.domain.aggregation.CourseCompletionAggregation;
 import uk.gov.cshr.report.service.CourseCompletionService;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.List;
-
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest({CourseCompletionsController.class, ApiExceptionHandler.class, ErrorDtoFactory.class})
+@WebMvcTest({CourseCompletionsController.class,  ApiExceptionHandler.class, ErrorDtoFactory.class})
 @ExtendWith(SpringExtension.class)
 @WithMockUser(username = "user")
 public class CourseCompletionsControllerTest {
@@ -37,39 +30,17 @@ public class CourseCompletionsControllerTest {
     @MockBean
     private CourseCompletionService courseCompletionService;
 
-    private CourseCompletionAggregation mockCourseCompletionAggregation(String courseId, Integer count, ZonedDateTime dateBin) {
-        return new CourseCompletionAggregation() {
-            @Override
-            public String getCourseId() {
-                return courseId;
-            }
-
-            @Override
-            public ZonedDateTime getdateBin() {
-                return dateBin;
-            }
-
-            @Override
-            public Integer getTotal() {
-                return count;
-            }
-        };
-    }
-
     @Test
     @WithMockUser(username = "user")
     public void shouldValidateParams() throws Exception {
 
-        when(courseCompletionService.getCourseCompletions(any())).thenReturn(List.of(
-                mockCourseCompletionAggregation("c1", 1, ZonedDateTime.of(LocalDateTime.of(2024, 1, 1, 1, 1), ZoneId.systemDefault()))
-        ));
-
         mockMvc.perform(
-                get("/course-completions/aggregations/by-course")
-                        .param("startDate", "2018-01-")
-                        .param("endDate", "2018-01-")
+                post("/course-completions/aggregations/by-course")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"startDate\": \"2018-01-\", \"endDate\": \"2018-01-\", \"courseIds\": null, \"organisationIds\": null}")
                         .with(csrf())
-                        .accept("application/json"))
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8"))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string(containsString("Field courseIds is invalid: must not be null")))

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -37,16 +37,14 @@ public class CourseCompletionsControllerTest {
         mockMvc.perform(
                 post("/course-completions/aggregations/by-course")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"startDate\": \"2018-01-\", \"endDate\": \"2018-01-\", \"courseIds\": null, \"organisationIds\": null}")
+                        .content("{\"startDate\": \"2018-01-01\", \"endDate\": \"2018-01-01\", \"courseIds\": [], \"organisationIds\": []}")
                         .with(csrf())
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8"))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(content().string(containsString("Field courseIds is invalid: must not be null")))
-                .andExpect(content().string(containsString("Field organisationIds is invalid: must not be null")))
-                .andExpect(content().string(containsString("Failed to convert property value of type 'java.lang.String' to required type 'java.time.LocalDate' for property 'endDate'")))
-                .andExpect(content().string(containsString("Failed to convert property value of type 'java.lang.String' to required type 'java.time.LocalDate' for property 'startDate'")));
+                .andExpect(content().string(containsString("Field courseIds is invalid: size must be between 1 and 10")))
+                .andExpect(content().string(containsString("Field organisationIds is invalid: size must be between 1 and 400")));
     }
 
 }

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -37,7 +37,7 @@ public class CourseCompletionsControllerTest {
         mockMvc.perform(
                 post("/course-completions/aggregations/by-course")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"startDate\": \"2018-01-01\", \"endDate\": \"2018-01-01\", \"courseIds\": [], \"organisationIds\": []}")
+                        .content("{\"startDate\": \"2018-01-01T00:00:00Z\", \"endDate\": \"2018-01-01T00:00:00Z\", \"courseIds\": [], \"organisationIds\": []}")
                         .with(csrf())
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8"))

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -43,7 +43,7 @@ public class CourseCompletionsControllerTest {
                         .characterEncoding("utf-8"))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(content().string(containsString("Field courseIds is invalid: size must be between 1 and 10")))
+                .andExpect(content().string(containsString("Field courseIds is invalid: size must be between 1 and 30")))
                 .andExpect(content().string(containsString("Field organisationIds is invalid: size must be between 1 and 400")));
     }
 

--- a/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
@@ -22,8 +22,8 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
     public void testGetAggregationsByHour() {
         String input = """
                 {
-                    "startDate": "2024-01-01T00:00:00Z",
-                    "endDate": "2024-01-02T00:00:00Z",
+                    "startDate": "2024-01-01",
+                    "endDate": "2024-01-02",
                     "courseIds": ["c1", "c2"],
                     "organisationIds": [1],
                     "binDelimiter": "HOUR"
@@ -61,8 +61,8 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
     public void testGetAggregationsByDay() {
         String input = """
                 {
-                    "startDate": "2024-01-01T00:00:00Z",
-                    "endDate": "2024-02-04T00:00:00Z",
+                    "startDate": "2024-01-01",
+                    "endDate": "2024-02-04",
                     "courseIds": ["c1", "c3"],
                     "organisationIds": [1],
                     "binDelimiter": "DAY"
@@ -91,8 +91,8 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
     public void testGetAggregationsByWeek() {
         String input = """
                 {
-                    "startDate": "2024-01-01T00:00:00Z",
-                    "endDate": "2024-03-21T00:00:00Z",
+                    "startDate": "2024-01-01",
+                    "endDate": "2024-03-21",
                     "courseIds": ["c1", "c2", "c3"],
                     "organisationIds": [1],
                     "professionIds": [2, 4],
@@ -131,8 +131,8 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
     public void testGetAggregationsByMonth() {
         String input = """
                 {
-                    "startDate": "2024-01-01T00:00:00Z",
-                    "endDate": "2024-06-02T00:00:00Z",
+                    "startDate": "2024-01-01",
+                    "endDate": "2024-06-02",
                     "courseIds": ["c1", "c2", "c3", "c4", "c5"],
                     "organisationIds": [1, 2, 3],
                     "binDelimiter": "MONTH"

--- a/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
@@ -5,7 +5,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
 import uk.gov.cshr.report.configuration.TestConfig;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -18,15 +20,20 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
 
     @Test
     public void testGetAggregationsByHour() {
+        String input = """
+                {
+                    "startDate": "2024-01-01",
+                    "endDate": "2024-01-02",
+                    "courseIds": ["c1", "c2"],
+                    "organisationIds": [1],
+                    "binDelimiter": "HOUR"
+                }
+                """;
         webTestClient
-                .get()
-                .uri(uriBuilder -> uriBuilder.path( "/course-completions/aggregations/by-course")
-                        .queryParam("startDate", "2024-01-01")
-                        .queryParam("endDate", "2024-01-02")
-                        .queryParam("courseIds", "c1, c2")
-                        .queryParam("organisationIds", "1")
-                        .queryParam("binDelimiter", "HOUR")
-                        .build())
+                .post()
+                .uri("/course-completions/aggregations/by-course")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(input))
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
@@ -52,15 +59,20 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
 
     @Test
     public void testGetAggregationsByDay() {
+        String input = """
+                {
+                    "startDate": "2024-01-01",
+                    "endDate": "2024-02-04",
+                    "courseIds": ["c1", "c3"],
+                    "organisationIds": [1],
+                    "binDelimiter": "DAY"
+                }
+                """;
         webTestClient
-                .get()
-                .uri(uriBuilder -> uriBuilder.path( "/course-completions/aggregations/by-course")
-                        .queryParam("startDate", "2024-01-01")
-                        .queryParam("endDate", "2024-02-04")
-                        .queryParam("courseIds", "c1, c3")
-                        .queryParam("organisationIds", "1")
-                        .queryParam("binDelimiter", "DAY")
-                        .build())
+                .post()
+                .uri("/course-completions/aggregations/by-course")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(input))
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
@@ -77,16 +89,21 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
 
     @Test
     public void testGetAggregationsByWeek() {
+        String input = """
+                {
+                    "startDate": "2024-01-01",
+                    "endDate": "2024-03-21",
+                    "courseIds": ["c1", "c2", "c3"],
+                    "organisationIds": [1],
+                    "professionIds": [2, 4],
+                    "binDelimiter": "WEEK"
+                }
+                """;
         webTestClient
-                .get()
-                .uri(uriBuilder -> uriBuilder.path( "/course-completions/aggregations/by-course")
-                        .queryParam("startDate", "2024-01-01")
-                        .queryParam("endDate", "2024-03-21")
-                        .queryParam("courseIds", "c1, c2, c3")
-                        .queryParam("organisationIds", "1")
-                        .queryParam("professionIds", "2, 4")
-                        .queryParam("binDelimiter", "WEEK")
-                        .build())
+                .post()
+                .uri("/course-completions/aggregations/by-course")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(input))
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
@@ -112,15 +129,20 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
 
     @Test
     public void testGetAggregationsByMonth() {
+        String input = """
+                {
+                    "startDate": "2024-01-01",
+                    "endDate": "2024-06-02",
+                    "courseIds": ["c1", "c2", "c3", "c4", "c5"],
+                    "organisationIds": [1, 2, 3],
+                    "binDelimiter": "MONTH"
+                }
+                """;
         webTestClient
-                .get()
-                .uri(uriBuilder -> uriBuilder.path( "/course-completions/aggregations/by-course")
-                        .queryParam("startDate", "2024-01-01")
-                        .queryParam("endDate", "2024-06-02")
-                        .queryParam("courseIds", "c1, c2, c3, c4, c5")
-                        .queryParam("organisationIds", "1, 2, 3")
-                        .queryParam("binDelimiter", "MONTH")
-                        .build())
+                .post()
+                .uri("/course-completions/aggregations/by-course")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(input))
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()

--- a/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
@@ -22,8 +22,8 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
     public void testGetAggregationsByHour() {
         String input = """
                 {
-                    "startDate": "2024-01-01",
-                    "endDate": "2024-01-02",
+                    "startDate": "2024-01-01T00:00:00Z",
+                    "endDate": "2024-01-02T00:00:00Z",
                     "courseIds": ["c1", "c2"],
                     "organisationIds": [1],
                     "binDelimiter": "HOUR"
@@ -61,8 +61,8 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
     public void testGetAggregationsByDay() {
         String input = """
                 {
-                    "startDate": "2024-01-01",
-                    "endDate": "2024-02-04",
+                    "startDate": "2024-01-01T00:00:00Z",
+                    "endDate": "2024-02-04T00:00:00Z",
                     "courseIds": ["c1", "c3"],
                     "organisationIds": [1],
                     "binDelimiter": "DAY"
@@ -91,8 +91,8 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
     public void testGetAggregationsByWeek() {
         String input = """
                 {
-                    "startDate": "2024-01-01",
-                    "endDate": "2024-03-21",
+                    "startDate": "2024-01-01T00:00:00Z",
+                    "endDate": "2024-03-21T00:00:00Z",
                     "courseIds": ["c1", "c2", "c3"],
                     "organisationIds": [1],
                     "professionIds": [2, 4],
@@ -131,8 +131,8 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
     public void testGetAggregationsByMonth() {
         String input = """
                 {
-                    "startDate": "2024-01-01",
-                    "endDate": "2024-06-02",
+                    "startDate": "2024-01-01T00:00:00Z",
+                    "endDate": "2024-06-02T00:00:00Z",
                     "courseIds": ["c1", "c2", "c3", "c4", "c5"],
                     "organisationIds": [1, 2, 3],
                     "binDelimiter": "MONTH"


### PR DESCRIPTION
- Tweak the course completion aggregation endpoint to use a POST body instead of GET query params. This is because the query params won't support a full ist of all of the possible organisation IDs