### PR TITLE
LC-2977: MVP course completion report - Exported csv content

### DIFF
--- a/src/main/java/uk/gov/cshr/report/domain/CourseCompletionEvent.java
+++ b/src/main/java/uk/gov/cshr/report/domain/CourseCompletionEvent.java
@@ -37,14 +37,25 @@ public class CourseCompletionEvent {
     @Column(nullable = false)
     private Integer organisationId;
 
+    @Column
+    private String organisationAbbreviation;
+
     @Column(nullable = false)
     private Integer professionId;
 
     @Column
+    private String professionName;
+
+    @Column
     private Integer gradeId;
 
+    @Column
+    private String gradeCode;
+
+
+
     public CourseCompletionEvent(String externalId, String userId, String userEmail, String courseId, String courseTitle,
-                                 LocalDateTime eventTimestamp, Integer organisationId, Integer professionId, Integer gradeId) {
+                                 LocalDateTime eventTimestamp, Integer organisationId, String organisationAbbreviation, Integer professionId, String professionName, Integer gradeId, String gradeCode) {
         this.externalId = externalId;
         this.userId = userId;
         this.userEmail = userEmail;
@@ -52,8 +63,11 @@ public class CourseCompletionEvent {
         this.courseTitle = courseTitle;
         this.eventTimestamp = eventTimestamp.atZone(ZoneId.systemDefault());
         this.organisationId = organisationId;
+        this.organisationAbbreviation = organisationAbbreviation;
         this.professionId = professionId;
+        this.professionName = professionName;
         this.gradeId = gradeId;
+        this.gradeCode = gradeCode;
     }
 
     public CourseCompletionEvent() {

--- a/src/main/java/uk/gov/cshr/report/service/messaging/coursecompletions/CourseCompletionMessage.java
+++ b/src/main/java/uk/gov/cshr/report/service/messaging/coursecompletions/CourseCompletionMessage.java
@@ -19,8 +19,11 @@ public final class CourseCompletionMessage implements IMessageMetadata, Serializ
     private final String courseId;
     private final String courseTitle;
     private final Integer organisationId;
+    private final String organisationAbbreviation;
     private final Integer professionId;
+    private final String professionName;
     private final Integer gradeId;
+    private final String gradeCode;
 
     @Override
     public String getQueue() {

--- a/src/main/java/uk/gov/cshr/report/service/messaging/coursecompletions/CourseCompletionsMessageConverter.java
+++ b/src/main/java/uk/gov/cshr/report/service/messaging/coursecompletions/CourseCompletionsMessageConverter.java
@@ -12,6 +12,7 @@ public class CourseCompletionsMessageConverter implements MessageToEntityConvert
         CourseCompletionMessage metadata = message.getMetadata();
         return new CourseCompletionEvent(message.getMessageId(), metadata.getUserId(), metadata.getUserEmail(),
                 metadata.getCourseId(), metadata.getCourseTitle(), metadata.getCompletionDate(), metadata.getOrganisationId(),
-                metadata.getProfessionId(), metadata.getGradeId());
+                metadata.getOrganisationAbbreviation(),
+                metadata.getProfessionId(), metadata.getProfessionName(), metadata.getGradeId(), metadata.getGradeCode());
     }
 }

--- a/src/main/resources/db/migration/postgresql/V2__add-columns-to-events-table.sql
+++ b/src/main/resources/db/migration/postgresql/V2__add-columns-to-events-table.sql
@@ -1,0 +1,4 @@
+ALTER TABLE course_completion_events
+    ADD COLUMN grade_code VARCHAR(100),
+    ADD COLUMN profession_name VARCHAR(255),
+    ADD COLUMN organisation_abbreviation VARCHAR(255);


### PR DESCRIPTION
This change 
* updates the Course Completion Event model to include 3 new columns: `professionName`, `organisationAbbreviation` and `gradeCode`.
* Updates the completions message module to include these 3 columns
* Creates a new Flyway script which adds the 3 new columns to the `course_completion_events` table in the reporting database.