### PR TITLE
LC-2868: Create Course Completion Report Requests Table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,12 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.hypersistence</groupId>
+            <artifactId>hypersistence-utils-hibernate-63</artifactId>
+            <version>3.8.1</version>
+        </dependency>
+
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
@@ -3,6 +3,7 @@ package uk.gov.cshr.report.controller;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import uk.gov.cshr.report.controller.model.AggregationResponse;
 import uk.gov.cshr.report.controller.model.DeleteUserDetailsParams;
 import uk.gov.cshr.report.controller.model.GetCourseCompletionsParams;
+import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
 import uk.gov.cshr.report.domain.aggregation.CourseCompletionAggregation;
 import uk.gov.cshr.report.service.CourseCompletionService;
 
@@ -40,5 +42,17 @@ public class CourseCompletionsController {
     @ResponseBody
     public int removeUserDetails(@RequestBody DeleteUserDetailsParams deleteUserDetailsParams) {
         return courseCompletionService.removeUserDetails(deleteUserDetailsParams.getUids());
+    }
+
+    @PostMapping("/report-requests")
+    public ResponseEntity<CourseCompletionReportRequest> addReportRequest(@RequestBody CourseCompletionReportRequest reportRequest){
+        CourseCompletionReportRequest savedRequest = courseCompletionService.addReportRequest(reportRequest);
+        return ResponseEntity.ok(savedRequest);
+    }
+
+    @GetMapping("/report-requests")
+    @ResponseBody
+    public List<CourseCompletionReportRequest> getAllReportRequests(){
+        return courseCompletionService.findAllReportRequests();
     }
 }

--- a/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
@@ -68,7 +68,7 @@ public class CourseCompletionsController {
 
     @GetMapping("/report-requests")
     @ResponseBody
-    public Map<String, List<CourseCompletionReportRequest>> getAllReportRequests(@RequestBody GetCourseCompletionsReportRequestParams params){
+    public Map<String, List<CourseCompletionReportRequest>> getAllReportRequests(@RequestBody @Valid GetCourseCompletionsReportRequestParams params){
         List<CourseCompletionReportRequest> reportRequests = courseCompletionReportRequestService.findReportRequestsByUserIdAndStatus(params);
         Map<String, List<CourseCompletionReportRequest>> response = new HashMap<>();
         response.put("requests", reportRequests);

--- a/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
@@ -45,7 +45,7 @@ public class CourseCompletionsController {
     }
 
     @PostMapping("/report-requests")
-    public ResponseEntity<CourseCompletionReportRequest> addReportRequest(@RequestBody CourseCompletionReportRequest reportRequest){
+    public ResponseEntity<CourseCompletionReportRequest> addReportRequest(@RequestBody @Valid CourseCompletionReportRequest reportRequest){
         CourseCompletionReportRequest savedRequest = courseCompletionService.addReportRequest(reportRequest);
         return ResponseEntity.ok(savedRequest);
     }

--- a/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
@@ -3,7 +3,6 @@ package uk.gov.cshr.report.controller;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,9 +16,7 @@ import uk.gov.cshr.report.domain.aggregation.CourseCompletionAggregation;
 import uk.gov.cshr.report.service.CourseCompletionReportRequestService;
 import uk.gov.cshr.report.service.CourseCompletionService;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Controller
@@ -52,26 +49,19 @@ public class CourseCompletionsController {
 
     @PostMapping("/report-requests")
     @ResponseBody
-    public Map<String, Object> addReportRequest(@RequestBody @Valid PostCourseCompletionsReportRequestParams params){
-        Map<String, Object> response = new HashMap<>();
-
+    public AddCourseCompletionReportRequestResponse addReportRequest(@RequestBody @Valid PostCourseCompletionsReportRequestParams params){
         if(courseCompletionReportRequestService.userReachedMaxReportRequests(params.getUserId())){
-            response.put("addedSuccessfully", false);
-            response.put("reason", "User has reached the maximum allowed report requests");
-            return response;
+            return new AddCourseCompletionReportRequestResponse(false, "User has reached the maximum allowed report requests");
         }
         CourseCompletionReportRequest reportRequest = postCourseCompletionsReportRequestsParamsToReportRequestMapper.getRequestFromParams(params);
         courseCompletionReportRequestService.addReportRequest(reportRequest);
-        response.put("addedSuccessfully", true);
-        return response;
+        return new AddCourseCompletionReportRequestResponse(true);
     }
 
     @GetMapping("/report-requests")
     @ResponseBody
-    public Map<String, List<CourseCompletionReportRequest>> getAllReportRequests(@RequestBody @Valid GetCourseCompletionsReportRequestParams params){
+    public GetCourseCompletionReportRequestsResponse getAllReportRequests(@RequestBody @Valid GetCourseCompletionsReportRequestParams params){
         List<CourseCompletionReportRequest> reportRequests = courseCompletionReportRequestService.findReportRequestsByUserIdAndStatus(params);
-        Map<String, List<CourseCompletionReportRequest>> response = new HashMap<>();
-        response.put("requests", reportRequests);
-        return response;
+        return new GetCourseCompletionReportRequestsResponse(reportRequests);
     }
 }

--- a/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
@@ -14,6 +14,7 @@ import uk.gov.cshr.report.controller.mappers.PostCourseCompletionsReportRequests
 import uk.gov.cshr.report.controller.model.*;
 import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
 import uk.gov.cshr.report.domain.aggregation.CourseCompletionAggregation;
+import uk.gov.cshr.report.service.CourseCompletionReportRequestService;
 import uk.gov.cshr.report.service.CourseCompletionService;
 
 import java.util.HashMap;
@@ -26,10 +27,12 @@ import java.util.Map;
 public class CourseCompletionsController {
 
     private final CourseCompletionService courseCompletionService;
+    private final CourseCompletionReportRequestService courseCompletionReportRequestService;
     private final PostCourseCompletionsReportRequestsParamsToReportRequestMapper postCourseCompletionsReportRequestsParamsToReportRequestMapper;
 
-    public CourseCompletionsController(CourseCompletionService courseCompletionService) {
+    public CourseCompletionsController(CourseCompletionService courseCompletionService, CourseCompletionReportRequestService courseCompletionReportRequestService) {
         this.courseCompletionService = courseCompletionService;
+        this.courseCompletionReportRequestService = courseCompletionReportRequestService;
         this.postCourseCompletionsReportRequestsParamsToReportRequestMapper = new PostCourseCompletionsReportRequestsParamsToReportRequestMapper();
     }
 
@@ -52,13 +55,13 @@ public class CourseCompletionsController {
     public Map<String, Object> addReportRequest(@RequestBody @Valid PostCourseCompletionsReportRequestParams params){
         Map<String, Object> response = new HashMap<>();
 
-        if(courseCompletionService.userReachedMaxReportRequests(params.getUserId())){
+        if(courseCompletionReportRequestService.userReachedMaxReportRequests(params.getUserId())){
             response.put("addedSuccessfully", false);
             response.put("reason", "User has reached the maximum allowed report requests");
             return response;
         }
         CourseCompletionReportRequest reportRequest = postCourseCompletionsReportRequestsParamsToReportRequestMapper.getRequestFromParams(params);
-        courseCompletionService.addReportRequest(reportRequest);
+        courseCompletionReportRequestService.addReportRequest(reportRequest);
         response.put("addedSuccessfully", true);
         return response;
     }
@@ -66,7 +69,7 @@ public class CourseCompletionsController {
     @GetMapping("/report-requests")
     @ResponseBody
     public Map<String, List<CourseCompletionReportRequest>> getAllReportRequests(@RequestBody GetCourseCompletionsReportRequestParams params){
-        List<CourseCompletionReportRequest> reportRequests = courseCompletionService.findReportRequestsByUserIdAndStatus(params);
+        List<CourseCompletionReportRequest> reportRequests = courseCompletionReportRequestService.findReportRequestsByUserIdAndStatus(params);
         Map<String, List<CourseCompletionReportRequest>> response = new HashMap<>();
         response.put("requests", reportRequests);
         return response;

--- a/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
+++ b/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
@@ -18,6 +18,7 @@ public class PostCourseCompletionsReportRequestsParamsToReportRequestMapper {
         reportRequest.setCourseIds(params.getCourseIds());
         reportRequest.setOrganisationIds(params.getOrganisationIds());
         reportRequest.setProfessionIds(params.getProfessionIds());
+        reportRequest.setGradeIds(params.getGradeIds());
 
         return reportRequest;
     }

--- a/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
+++ b/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
@@ -1,0 +1,24 @@
+package uk.gov.cshr.report.controller.mappers;
+
+import uk.gov.cshr.report.controller.model.PostCourseCompletionsReportRequestParams;
+import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class PostCourseCompletionsReportRequestsParamsToReportRequestMapper {
+    public CourseCompletionReportRequest getRequestFromParams(PostCourseCompletionsReportRequestParams params) {
+        CourseCompletionReportRequest reportRequest = new CourseCompletionReportRequest();
+        reportRequest.setRequesterId(params.getUserId());
+        reportRequest.setRequesterEmail(params.getUserEmail());
+        reportRequest.setStatus("REQUESTED");
+        reportRequest.setRequestedTimestamp(ZonedDateTime.now());
+        reportRequest.setFromDate(params.getStartDate().atStartOfDay(ZoneOffset.UTC));
+        reportRequest.setToDate(params.getEndDate().atStartOfDay(ZoneOffset.UTC));
+        reportRequest.setCourseIds(params.getCourseIds());
+        reportRequest.setOrganisationIds(params.getOrganisationIds());
+        reportRequest.setProfessionIds(params.getProfessionIds());
+
+        return reportRequest;
+    }
+}

--- a/src/main/java/uk/gov/cshr/report/controller/model/AddCourseCompletionReportRequestResponse.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/AddCourseCompletionReportRequestResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.cshr.report.controller.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class AddCourseCompletionReportRequestResponse {
+    private final Boolean addedSuccessfully;
+    private String details;
+}

--- a/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionReportRequestsResponse.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionReportRequestsResponse.java
@@ -1,0 +1,13 @@
+package uk.gov.cshr.report.controller.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class GetCourseCompletionReportRequestsResponse {
+    private final List<CourseCompletionReportRequest> requests;
+}

--- a/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsReportRequestParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsReportRequestParams.java
@@ -1,0 +1,17 @@
+package uk.gov.cshr.report.controller.model;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetCourseCompletionsReportRequestParams {
+    @NotNull
+    private String userId;
+
+    @NotNull
+    private String status;
+}

--- a/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
@@ -1,0 +1,36 @@
+package uk.gov.cshr.report.controller.model;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostCourseCompletionsReportRequestParams {
+    @NotNull
+    private String userId;
+
+    @NotNull
+    private String userEmail;
+
+    @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    @NotNull
+    private List<String> courseIds;
+
+    private List<Integer> organisationIds;
+
+    private List<Integer> professionIds;
+}

--- a/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
@@ -33,4 +33,6 @@ public class PostCourseCompletionsReportRequestParams {
     private List<Integer> organisationIds;
 
     private List<Integer> professionIds;
+
+    private List<Integer> gradeIds;
 }

--- a/src/main/java/uk/gov/cshr/report/domain/CourseCompletionReportRequest.java
+++ b/src/main/java/uk/gov/cshr/report/domain/CourseCompletionReportRequest.java
@@ -1,7 +1,8 @@
 package uk.gov.cshr.report.domain;
-
+import io.hypersistence.utils.hibernate.type.array.ListArrayType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Type;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -10,7 +11,6 @@ import java.util.List;
 @Getter
 @Table(name = "course_completion_report_requests")
 @Setter
-@ToString
 public class CourseCompletionReportRequest {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,21 +38,20 @@ public class CourseCompletionReportRequest {
     @Column(name = "to_date", nullable = false)
     private ZonedDateTime toDate;
 
-    @ElementCollection
-    @CollectionTable(name = "course_completion_report_requests_course_ids", joinColumns = @JoinColumn(name = "report_request_id"))
-    @Column(name = "course_ids", nullable = false)
+    @Type(ListArrayType.class)
+    @Column(name = "course_ids", nullable = false, columnDefinition = "text[]")
     private List<String> courseIds;
 
-    @ElementCollection
-    @Column(name = "organisation_ids", nullable = false)
+    @Type(ListArrayType.class)
+    @Column(name = "organisation_ids", nullable = false, columnDefinition = "int[]")
     private List<Integer> organisationIds;
 
-    @ElementCollection
-    @Column(name = "profession_ids")
+    @Type(ListArrayType.class)
+    @Column(name = "profession_ids", columnDefinition = "int[]")
     private List<Integer> professionIds;
 
-    @ElementCollection
-    @Column(name = "grade_ids")
+    @Type(ListArrayType.class)
+    @Column(name = "grade_ids", columnDefinition = "int[]")
     private List<Integer> gradeIds;
 
 

--- a/src/main/java/uk/gov/cshr/report/domain/CourseCompletionReportRequest.java
+++ b/src/main/java/uk/gov/cshr/report/domain/CourseCompletionReportRequest.java
@@ -1,0 +1,59 @@
+package uk.gov.cshr.report.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "course_completion_report_requests")
+@Setter
+@ToString
+public class CourseCompletionReportRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_request_id")
+    private Long reportRequestId;
+
+    @Column(name = "requester_id", length = 36)
+    private String requesterId;
+
+    @Column(name = "requester_email", length = 100)
+    private String requesterEmail;
+
+    @Column(name = "requested_timestamp", nullable = false)
+    private ZonedDateTime requestedTimestamp;
+
+    @Column(name = "completed_timestamp")
+    private ZonedDateTime completedTimestamp;
+
+    @Column(name = "status", length = 20, nullable = false)
+    private String status;
+
+    @Column(name = "from_date", nullable = false)
+    private ZonedDateTime fromDate;
+
+    @Column(name = "to_date", nullable = false)
+    private ZonedDateTime toDate;
+
+    @ElementCollection
+    @CollectionTable(name = "course_completion_report_requests_course_ids", joinColumns = @JoinColumn(name = "report_request_id"))
+    @Column(name = "course_ids", nullable = false)
+    private List<String> courseIds;
+
+    @ElementCollection
+    @Column(name = "organisation_ids", nullable = false)
+    private List<Integer> organisationIds;
+
+    @ElementCollection
+    @Column(name = "profession_ids")
+    private List<Integer> professionIds;
+
+    @ElementCollection
+    @Column(name = "grade_ids")
+    private List<Integer> gradeIds;
+
+
+}

--- a/src/main/java/uk/gov/cshr/report/repository/CourseCompletionReportRequestRepository.java
+++ b/src/main/java/uk/gov/cshr/report/repository/CourseCompletionReportRequestRepository.java
@@ -1,8 +1,18 @@
 package uk.gov.cshr.report.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
+
+import java.util.List;
 
 public interface CourseCompletionReportRequestRepository extends JpaRepository<CourseCompletionReportRequest, Long> {
 
+    @Query("""
+        select r from CourseCompletionReportRequest r
+            where r.requesterId = :userId and r.status = :status
+    """)
+
+    List<CourseCompletionReportRequest> findAllByUserIdAndStatus(@Param("userId") String userId, @Param("status") String status);
 }

--- a/src/main/java/uk/gov/cshr/report/repository/CourseCompletionReportRequestRepository.java
+++ b/src/main/java/uk/gov/cshr/report/repository/CourseCompletionReportRequestRepository.java
@@ -1,18 +1,10 @@
 package uk.gov.cshr.report.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
 
 import java.util.List;
 
 public interface CourseCompletionReportRequestRepository extends JpaRepository<CourseCompletionReportRequest, Long> {
-
-    @Query("""
-        select r from CourseCompletionReportRequest r
-            where r.requesterId = :userId and r.status = :status
-    """)
-
-    List<CourseCompletionReportRequest> findAllByUserIdAndStatus(@Param("userId") String userId, @Param("status") String status);
+    List<CourseCompletionReportRequest> findByRequesterIdAndStatus(String requestedId, String status);
 }

--- a/src/main/java/uk/gov/cshr/report/repository/CourseCompletionReportRequestRepository.java
+++ b/src/main/java/uk/gov/cshr/report/repository/CourseCompletionReportRequestRepository.java
@@ -1,0 +1,8 @@
+package uk.gov.cshr.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
+
+public interface CourseCompletionReportRequestRepository extends JpaRepository<CourseCompletionReportRequest, Long> {
+
+}

--- a/src/main/java/uk/gov/cshr/report/service/CourseCompletionReportRequestService.java
+++ b/src/main/java/uk/gov/cshr/report/service/CourseCompletionReportRequestService.java
@@ -1,0 +1,36 @@
+package uk.gov.cshr.report.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.cshr.report.controller.model.GetCourseCompletionsReportRequestParams;
+import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
+import uk.gov.cshr.report.repository.CourseCompletionReportRequestRepository;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class CourseCompletionReportRequestService {
+    private final CourseCompletionReportRequestRepository courseCompletionReportRequestRepository;
+    private int maxRequestsPerUser;
+
+    public CourseCompletionReportRequestService(CourseCompletionReportRequestRepository courseCompletionReportRequestRepository, @Value("${courseCompletions.reports.maxRequestsPerUser}") int maxRequestsPerUser) {
+        this.courseCompletionReportRequestRepository = courseCompletionReportRequestRepository;
+        this.maxRequestsPerUser = maxRequestsPerUser;
+    }
+
+    public CourseCompletionReportRequest addReportRequest(CourseCompletionReportRequest reportRequest){
+        return courseCompletionReportRequestRepository.save(reportRequest);
+    }
+
+    public List<CourseCompletionReportRequest> findReportRequestsByUserIdAndStatus(GetCourseCompletionsReportRequestParams params){
+        return courseCompletionReportRequestRepository.findAllByUserIdAndStatus(params.getUserId(), params.getStatus());
+    }
+
+    public boolean userReachedMaxReportRequests(String userId){
+        GetCourseCompletionsReportRequestParams params = new GetCourseCompletionsReportRequestParams(userId, "REQUESTED");
+        List<CourseCompletionReportRequest> pendingRequests = findReportRequestsByUserIdAndStatus(params);
+        return pendingRequests.size() >= maxRequestsPerUser;
+    }
+}

--- a/src/main/java/uk/gov/cshr/report/service/CourseCompletionReportRequestService.java
+++ b/src/main/java/uk/gov/cshr/report/service/CourseCompletionReportRequestService.java
@@ -25,7 +25,7 @@ public class CourseCompletionReportRequestService {
     }
 
     public List<CourseCompletionReportRequest> findReportRequestsByUserIdAndStatus(GetCourseCompletionsReportRequestParams params){
-        return courseCompletionReportRequestRepository.findAllByUserIdAndStatus(params.getUserId(), params.getStatus());
+        return courseCompletionReportRequestRepository.findByRequesterIdAndStatus(params.getUserId(), params.getStatus());
     }
 
     public boolean userReachedMaxReportRequests(String userId){

--- a/src/main/java/uk/gov/cshr/report/service/CourseCompletionService.java
+++ b/src/main/java/uk/gov/cshr/report/service/CourseCompletionService.java
@@ -4,8 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import uk.gov.cshr.report.controller.model.GetCourseCompletionsParams;
+import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
 import uk.gov.cshr.report.domain.aggregation.CourseCompletionAggregation;
 import uk.gov.cshr.report.repository.CourseCompletionEventRepository;
+import uk.gov.cshr.report.repository.CourseCompletionReportRequestRepository;
 
 import java.util.List;
 
@@ -14,9 +16,11 @@ import java.util.List;
 public class CourseCompletionService {
 
     private final CourseCompletionEventRepository repository;
+    private final CourseCompletionReportRequestRepository courseCompletionReportRequestRepository;
 
-    public CourseCompletionService(CourseCompletionEventRepository repository) {
+    public CourseCompletionService(CourseCompletionEventRepository repository, CourseCompletionReportRequestRepository courseCompletionReportRequestRepository) {
         this.repository = repository;
+        this.courseCompletionReportRequestRepository = courseCompletionReportRequestRepository;
     }
 
     public List<CourseCompletionAggregation> getCourseCompletions(GetCourseCompletionsParams params) {
@@ -28,5 +32,13 @@ public class CourseCompletionService {
     public int removeUserDetails(List<String> uids) {
         log.info("Removing user details for UIDs: " + uids);
         return repository.removeUserDetails(uids);
+    }
+
+    public CourseCompletionReportRequest addReportRequest(CourseCompletionReportRequest reportRequest){
+        return courseCompletionReportRequestRepository.save(reportRequest);
+    }
+
+    public List<CourseCompletionReportRequest> findAllReportRequests(){
+        return courseCompletionReportRequestRepository.findAll();
     }
 }

--- a/src/main/java/uk/gov/cshr/report/service/CourseCompletionService.java
+++ b/src/main/java/uk/gov/cshr/report/service/CourseCompletionService.java
@@ -18,17 +18,10 @@ import java.util.List;
 public class CourseCompletionService {
 
     private final CourseCompletionEventRepository repository;
-    private final CourseCompletionReportRequestRepository courseCompletionReportRequestRepository;
-
-    private int maxRequestsPerUser;
 
     public CourseCompletionService(
-            CourseCompletionEventRepository repository,
-            CourseCompletionReportRequestRepository courseCompletionReportRequestRepository,
-            @Value("${courseCompletions.reports.maxRequestsPerUser}") int maxRequestsPerUser) {
+            CourseCompletionEventRepository repository) {
         this.repository = repository;
-        this.courseCompletionReportRequestRepository = courseCompletionReportRequestRepository;
-        this.maxRequestsPerUser = maxRequestsPerUser;
     }
 
     public List<CourseCompletionAggregation> getCourseCompletions(GetCourseCompletionsParams params) {
@@ -40,19 +33,5 @@ public class CourseCompletionService {
     public int removeUserDetails(List<String> uids) {
         log.info("Removing user details for UIDs: " + uids);
         return repository.removeUserDetails(uids);
-    }
-
-    public CourseCompletionReportRequest addReportRequest(CourseCompletionReportRequest reportRequest){
-        return courseCompletionReportRequestRepository.save(reportRequest);
-    }
-
-    public List<CourseCompletionReportRequest> findReportRequestsByUserIdAndStatus(GetCourseCompletionsReportRequestParams params){
-        return courseCompletionReportRequestRepository.findAllByUserIdAndStatus(params.getUserId(), params.getStatus());
-    }
-
-    public boolean userReachedMaxReportRequests(String userId){
-        GetCourseCompletionsReportRequestParams params = new GetCourseCompletionsReportRequestParams(userId, "REQUESTED");
-        List<CourseCompletionReportRequest> pendingRequests = findReportRequestsByUserIdAndStatus(params);
-        return pendingRequests.size() >= maxRequestsPerUser;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,6 +87,11 @@ learningCatalogue:
 
 report:
   backEndAPICallBatchSize: ${BACKEND_API_CALL_BATCH_SIZE:50}
+
+courseCompletions:
+  reports:
+    maxRequestsPerUser: ${MAX_REQUESTS_PER_USER:1}
+
 info:
   name: "Report service API"
   description: "Provides reporting and management information data"

--- a/src/main/resources/db/migration/postgresql/V2.1__add-report-requests-table.sql
+++ b/src/main/resources/db/migration/postgresql/V2.1__add-report-requests-table.sql
@@ -12,7 +12,7 @@ CREATE TABLE course_completion_report_requests (
     report_request_id SERIAL,
     requester_id VARCHAR(36),
     requester_email VARCHAR(100),
-    requested_timestamp TIMESTAMPTZ NOT NULL,
+    requested_timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
     completed_timestamp TIMESTAMPTZ,
     status VARCHAR(20) NOT NULL,
     from_date TIMESTAMPTZ NOT NULL,

--- a/src/main/resources/db/migration/postgresql/V2.1__add-report-requests-table.sql
+++ b/src/main/resources/db/migration/postgresql/V2.1__add-report-requests-table.sql
@@ -1,0 +1,33 @@
+CREATE TABLE report_requests_status (
+    status VARCHAR(20) PRIMARY KEY
+);
+
+INSERT INTO report_requests_status (status) VALUES
+    ('REQUESTED'),
+    ('PROCESSING'),
+    ('SUCCESS'),
+    ('FAILED');
+
+CREATE TABLE course_completion_report_requests (
+    report_request_id SERIAL,
+    requester_id VARCHAR(36),
+    requester_email VARCHAR(100),
+    requested_timestamp TIMESTAMPTZ NOT NULL,
+    completed_timestamp TIMESTAMPTZ,
+    status VARCHAR(20) NOT NULL,
+    from_date TIMESTAMPTZ NOT NULL,
+    to_date TIMESTAMPTZ NOT NULL,
+    course_ids text[] NOT NULL,
+    organisation_ids INT[] NOT NULL,
+    profession_ids INT[],
+    grade_ids INT[],
+
+    CONSTRAINT status_fk
+        FOREIGN KEY(status)
+            REFERENCES report_requests_status(status)
+);
+
+CREATE TABLE course_completion_report_requests_course_ids (
+    report_request_id INTEGER NOT NULL,
+    course_id TEXT NOT NULL
+);

--- a/src/main/resources/db/migration/postgresql/V2.1__add-report-requests-table.sql
+++ b/src/main/resources/db/migration/postgresql/V2.1__add-report-requests-table.sql
@@ -26,8 +26,3 @@ CREATE TABLE course_completion_report_requests (
         FOREIGN KEY(status)
             REFERENCES report_requests_status(status)
 );
-
-CREATE TABLE course_completion_report_requests_course_ids (
-    report_request_id INTEGER NOT NULL,
-    course_id TEXT NOT NULL
-);

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cshr.report.controller.model.ErrorDtoFactory;
+import uk.gov.cshr.report.service.CourseCompletionReportRequestService;
 import uk.gov.cshr.report.service.CourseCompletionService;
 
 import static org.hamcrest.Matchers.containsString;
@@ -30,6 +31,9 @@ public class CourseCompletionsControllerTest {
 
     @MockBean
     private CourseCompletionService courseCompletionService;
+
+    @MockBean
+    private CourseCompletionReportRequestService courseCompletionReportRequestService;
 
     @Test
     @WithMockUser(username = "user")

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -51,7 +51,7 @@ public class CourseCompletionsControllerTest {
     @Test
     @WithMockUser(username = "user")
     public void testPostReportRequestsEndpointReturnsOkWhenRequestBodyIsCorrect() throws Exception {
-        String requestBody = "{\"requesterId\": \"requester001\", \"requesterEmail\": \"learner@defra.org.uk\", \"requestedTimestamp\": \"2024-06-28T15:30:00.123456+00:00\", \"status\":\"REQUESTED\", \"fromDate\":\"2024-01-01T00:00:00.123456+00:00\", \"toDate\":\"2024-03-01T00:00:00.123456+00:00\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [1,2,3,4], \"gradeIds\": [1,2,3,4]}";
+        String requestBody = "{\"userId\": \"user003\", \"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01\", \"endDate\": \"2024-02-01\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8]}";
 
         mockMvc.perform(
                 post("/course-completions/report-requests")
@@ -62,6 +62,22 @@ public class CourseCompletionsControllerTest {
                     .characterEncoding("utf-8"))
                 .andDo(print())
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "user")
+    public void testPostReportRequestsEndpointReturnsOkWhenRequestBodyIsMissingRequiredFields() throws Exception {
+        String requestBody = "{\"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01\", \"endDate\": \"2024-02-01\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8]}";
+
+        mockMvc.perform(
+                        post("/course-completions/report-requests")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                                .with(csrf())
+                                .accept(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -79,16 +95,37 @@ public class CourseCompletionsControllerTest {
 
     @Test
     @WithMockUser(username = "user")
-    public void testGetReportRequestsEndpointReturnsOk() throws Exception {
-
+    public void testGetReportRequestsEndpointReturnsOkIfCorrectRequestBodyIsGiven() throws Exception {
+        String requestBody = "{\n" +
+                "    \"userId\": \"user003\",\n" +
+                "    \"status\": \"REQUESTED\"\n" +
+                "}";
         mockMvc.perform(
                         get("/course-completions/report-requests")
                                 .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
                                 .with(csrf())
                                 .accept(MediaType.APPLICATION_JSON)
                                 .characterEncoding("utf-8"))
                 .andDo(print())
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "user")
+    public void testGetReportRequestsEndpointReturnsBadRequestIfRequiredRequestBodyFieldIsMissing() throws Exception {
+        String requestBody = "{\n" +
+                "    \"userId\": \"user003\",\n" +
+                "}";
+        mockMvc.perform(
+                        get("/course-completions/report-requests")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody)
+                                .with(csrf())
+                                .accept(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 
 

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -14,6 +14,7 @@ import uk.gov.cshr.report.service.CourseCompletionService;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -46,5 +47,49 @@ public class CourseCompletionsControllerTest {
                 .andExpect(content().string(containsString("Field courseIds is invalid: size must be between 1 and 30")))
                 .andExpect(content().string(containsString("Field organisationIds is invalid: size must be between 1 and 400")));
     }
+
+    @Test
+    @WithMockUser(username = "user")
+    public void testPostReportRequestsEndpointReturnsOkWhenRequestBodyIsCorrect() throws Exception {
+        String requestBody = "{\"requesterId\": \"requester001\", \"requesterEmail\": \"learner@defra.org.uk\", \"requestedTimestamp\": \"2024-06-28T15:30:00.123456+00:00\", \"status\":\"REQUESTED\", \"fromDate\":\"2024-01-01T00:00:00.123456+00:00\", \"toDate\":\"2024-03-01T00:00:00.123456+00:00\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [1,2,3,4], \"gradeIds\": [1,2,3,4]}";
+
+        mockMvc.perform(
+                post("/course-completions/report-requests")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "user")
+    public void testPostReportRequestsEndpointReturnsBadGatewayWhenNoRequestBodyIsGiven() throws Exception {
+        mockMvc.perform(
+                        post("/course-completions/report-requests")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(csrf())
+                                .accept(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "user")
+    public void testGetReportRequestsEndpointReturnsOk() throws Exception {
+
+        mockMvc.perform(
+                        get("/course-completions/report-requests")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(csrf())
+                                .accept(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
 
 }


### PR DESCRIPTION
This change:

* Adds the [Hypersistence Utils](https://github.com/vladmihalcea/hypersistence-utils) library as a dependency to add support for Postgres array column types.
* Adds a new Flyway schema entry which creates two new tables: `course_completion_report_requests` and `report_requests_status`.
* Creates a new `CourseCompletionReportRequest` entity to match the schema of the `course_completion_report_requests` table.
* Creates a new Repository class for saving and getting repository request entries to the database
* Creates a new service `CourseCompletionReportRequestService` to save and get report requests.
* Creates 2 new endpoints: `POST /course-completions/report-requests` to save new report requests and `GET /course-completions/report-requests` to retrieve requests.