### PR TITLE
LC-2842 / LC-2867: Course completions request emails

### DIFF
--- a/src/main/java/uk/gov/cshr/report/client/HttpClient.java
+++ b/src/main/java/uk/gov/cshr/report/client/HttpClient.java
@@ -18,6 +18,24 @@ public class HttpClient implements IHttpClient {
 
     private final RestTemplate restTemplate;
 
+    @Override
+    public <T, R> T executeRequest(RequestEntity<R> request, Class<T> responseClass) {
+        try {
+            log.debug("Sending request: {}", request);
+            ResponseEntity<T> response = restTemplate.exchange(request, responseClass);
+            log.debug("Request response: {}", response);
+            return response.getBody();
+        } catch (RestClientResponseException e) {
+            String msg = String.format("Error sending '%s' request to endpoint", request.getMethod());
+            if (request.getBody() != null) {
+                msg = String.format("%s Body was: %s.", msg, request.getBody().toString());
+            }
+            msg = String.format("%s Error was: %s", msg, e.getMessage());
+            log.error(msg);
+            throw e;
+        }
+    }
+
     public <T, R> Map<String, T> executeMapRequest(RequestEntity<R> request, ParameterizedTypeReference<Map<String, T>> ptr) {
         try {
             log.debug("Sending request: {}", request);

--- a/src/main/java/uk/gov/cshr/report/client/IHttpClient.java
+++ b/src/main/java/uk/gov/cshr/report/client/IHttpClient.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface IHttpClient {
+    <T, R> T executeRequest(RequestEntity<R> request, Class<T> responseClass);
     <T, R> Map<String, T> executeMapRequest(RequestEntity<R> request, ParameterizedTypeReference<Map<String, T>> parameterizedTypeReference);
     <T, R> List<T> executeListRequest(RequestEntity<R> request, ParameterizedTypeReference<List<T>> parameterizedTypeReference);
 }

--- a/src/main/java/uk/gov/cshr/report/client/identity/oauth/IOAuthClient.java
+++ b/src/main/java/uk/gov/cshr/report/client/identity/oauth/IOAuthClient.java
@@ -1,0 +1,5 @@
+package uk.gov.cshr.report.client.identity.oauth;
+
+public interface IOAuthClient {
+    String getAccessToken(String basicAuthClientId, String basicAuthClientSecret);
+}

--- a/src/main/java/uk/gov/cshr/report/client/identity/oauth/OAuthClient.java
+++ b/src/main/java/uk/gov/cshr/report/client/identity/oauth/OAuthClient.java
@@ -1,0 +1,44 @@
+package uk.gov.cshr.report.client.identity.oauth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import uk.gov.cshr.report.client.IHttpClient;
+import uk.gov.cshr.report.domain.identity.OAuthToken;
+import uk.gov.cshr.report.service.ParameterizedTypeReferenceFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class OAuthClient implements IOAuthClient {
+    private final IHttpClient client;
+
+    public OAuthClient(@Qualifier("oAuthClient") IHttpClient client) {
+        this.client = client;
+    }
+
+    @Value("${oauth.tokenUrl}")
+    private String oauthTokenUrl;
+
+    @Override
+    public String getAccessToken(String basicAuthClientId, String basicAuthClientSecret) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth(basicAuthClientId, basicAuthClientSecret);
+
+        RequestEntity<Void> request = RequestEntity
+                .post(oauthTokenUrl + "?grant_type=client_credentials")
+                .headers(headers).build();
+
+        OAuthToken response = client.executeRequest(request, OAuthToken.class);
+
+        return response.getAccessToken();
+    }
+}

--- a/src/main/java/uk/gov/cshr/report/client/identity/oauth/OAuthTokenRequestBody.java
+++ b/src/main/java/uk/gov/cshr/report/client/identity/oauth/OAuthTokenRequestBody.java
@@ -1,0 +1,16 @@
+package uk.gov.cshr.report.client.identity.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OAuthTokenRequestBody {
+    @JsonProperty("grant_type")
+    private String grantType;
+}

--- a/src/main/java/uk/gov/cshr/report/client/notification/INotificationClient.java
+++ b/src/main/java/uk/gov/cshr/report/client/notification/INotificationClient.java
@@ -1,0 +1,7 @@
+package uk.gov.cshr.report.client.notification;
+
+import uk.gov.cshr.report.dto.MessageDto;
+
+public interface INotificationClient {
+    void sendEmail(String templateName, MessageDto messageDto);
+}

--- a/src/main/java/uk/gov/cshr/report/client/notification/INotificationClient.java
+++ b/src/main/java/uk/gov/cshr/report/client/notification/INotificationClient.java
@@ -3,5 +3,5 @@ package uk.gov.cshr.report.client.notification;
 import uk.gov.cshr.report.dto.MessageDto;
 
 public interface INotificationClient {
-    void sendEmail(String templateName, MessageDto messageDto);
+    void sendEmail(String accessToken, String templateName, MessageDto messageDto);
 }

--- a/src/main/java/uk/gov/cshr/report/client/notification/NotificationClient.java
+++ b/src/main/java/uk/gov/cshr/report/client/notification/NotificationClient.java
@@ -1,0 +1,29 @@
+package uk.gov.cshr.report.client.notification;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import uk.gov.cshr.report.client.IHttpClient;
+import uk.gov.cshr.report.dto.MessageDto;
+
+@Slf4j
+@Component
+public class NotificationClient implements INotificationClient {
+    private IHttpClient httpClient;
+
+    @Value("${notification.sendEmailEndpointTemplate}")
+    private String sendEmailEndpointTemplate;
+
+    public NotificationClient(@Qualifier("notificationHttpClient") IHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public void sendEmail(String templateName, MessageDto messageDto) {
+        String emailEndpoint = sendEmailEndpointTemplate.replace("{{TEMPLATE_NAME}}", templateName);
+        RequestEntity<MessageDto> request = RequestEntity.post(emailEndpoint).body(messageDto);
+        httpClient.executeRequest(request, Void.class);
+    }
+}

--- a/src/main/java/uk/gov/cshr/report/client/notification/NotificationClient.java
+++ b/src/main/java/uk/gov/cshr/report/client/notification/NotificationClient.java
@@ -3,6 +3,7 @@ package uk.gov.cshr.report.client.notification;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
 import uk.gov.cshr.report.client.IHttpClient;
@@ -21,9 +22,17 @@ public class NotificationClient implements INotificationClient {
     }
 
     @Override
-    public void sendEmail(String templateName, MessageDto messageDto) {
+    public void sendEmail(String accessToken, String templateName, MessageDto messageDto) {
         String emailEndpoint = sendEmailEndpointTemplate.replace("{{TEMPLATE_NAME}}", templateName);
-        RequestEntity<MessageDto> request = RequestEntity.post(emailEndpoint).body(messageDto);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        RequestEntity<MessageDto> request = RequestEntity
+                .post(emailEndpoint)
+                .headers(headers)
+                .body(messageDto);
+
         httpClient.executeRequest(request, Void.class);
     }
 }

--- a/src/main/java/uk/gov/cshr/report/config/NotificationClientConfig.java
+++ b/src/main/java/uk/gov/cshr/report/config/NotificationClientConfig.java
@@ -1,0 +1,34 @@
+package uk.gov.cshr.report.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.cshr.report.client.HttpClient;
+import uk.gov.cshr.report.client.IHttpClient;
+import uk.gov.cshr.report.service.auth.RestTemplateOAuthInterceptor;
+
+@Configuration
+public class NotificationClientConfig {
+    @Value("${notification.serviceUrl}")
+    private String notificationServiceUrl;
+
+    private final RestTemplateOAuthInterceptor restTemplateOAuthInterceptor;
+
+    public NotificationClientConfig(RestTemplateOAuthInterceptor restTemplateOAuthInterceptor){
+        this.restTemplateOAuthInterceptor = restTemplateOAuthInterceptor;
+    }
+
+    @Bean(name = "notificationHttpClient")
+    IHttpClient notificationClient(RestTemplateBuilder restTemplateBuilder){
+        RestTemplate restTemplate = restTemplateBuilder
+                .rootUri(notificationServiceUrl)
+                .additionalInterceptors(restTemplateOAuthInterceptor)
+                .build();
+
+        return new HttpClient(restTemplate);
+    }
+
+
+}

--- a/src/main/java/uk/gov/cshr/report/config/OAuthClientConfig.java
+++ b/src/main/java/uk/gov/cshr/report/config/OAuthClientConfig.java
@@ -9,14 +9,14 @@ import uk.gov.cshr.report.client.HttpClient;
 import uk.gov.cshr.report.client.IHttpClient;
 
 @Configuration
-public class NotificationClientConfig {
-    @Value("${notification.serviceUrl}")
-    private String notificationServiceUrl;
+public class OAuthClientConfig {
+    @Value("${oauth.serviceUrl}")
+    private String oAuthServiceUrl;
 
-    @Bean(name = "notificationHttpClient")
-    IHttpClient notificationClient(RestTemplateBuilder restTemplateBuilder){
+    @Bean(name = "oAuthClient")
+    IHttpClient oAuthClient(RestTemplateBuilder restTemplateBuilder){
         RestTemplate restTemplate = restTemplateBuilder
-                .rootUri(notificationServiceUrl)
+                .rootUri(oAuthServiceUrl)
                 .build();
 
         return new HttpClient(restTemplate);

--- a/src/main/java/uk/gov/cshr/report/domain/identity/OAuthToken.java
+++ b/src/main/java/uk/gov/cshr/report/domain/identity/OAuthToken.java
@@ -1,0 +1,30 @@
+package uk.gov.cshr.report.domain.identity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OAuthToken implements Serializable {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+
+    @JsonProperty("jti")
+    private String jti;
+}

--- a/src/main/java/uk/gov/cshr/report/dto/MessageDto.java
+++ b/src/main/java/uk/gov/cshr/report/dto/MessageDto.java
@@ -1,0 +1,23 @@
+package uk.gov.cshr.report.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageDto {
+    @Email(message="{message.recipient.valid}")
+    @NotEmpty(message = "{message.recipient.required}")
+    private String recipient;
+
+    private Map<String, String> personalisation;
+
+    String reference = UUID.randomUUID().toString();
+}

--- a/src/main/java/uk/gov/cshr/report/service/NotificationService.java
+++ b/src/main/java/uk/gov/cshr/report/service/NotificationService.java
@@ -1,0 +1,30 @@
+package uk.gov.cshr.report.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.cshr.report.client.notification.INotificationClient;
+import uk.gov.cshr.report.dto.MessageDto;
+
+@Service
+public class NotificationService {
+    private final INotificationClient notificationClient;
+
+    @Value("${notification.successEmailTemplateName}")
+    private String successEmailTemplateName;
+
+    @Value("${notification.failureEmailTemplateName}")
+    private String failureEmailTemplateName;
+
+    public NotificationService(INotificationClient notificationClient) {
+        this.notificationClient = notificationClient;
+    }
+
+    public void sendSuccessEmail(MessageDto messageDto){
+        notificationClient.sendEmail(successEmailTemplateName, messageDto);
+    }
+
+    public void sendFailureEmail(MessageDto messageDto){
+        notificationClient.sendEmail(failureEmailTemplateName, messageDto);
+    }
+
+}

--- a/src/main/java/uk/gov/cshr/report/service/NotificationService.java
+++ b/src/main/java/uk/gov/cshr/report/service/NotificationService.java
@@ -19,12 +19,12 @@ public class NotificationService {
         this.notificationClient = notificationClient;
     }
 
-    public void sendSuccessEmail(MessageDto messageDto){
-        notificationClient.sendEmail(successEmailTemplateName, messageDto);
+    public void sendSuccessEmail(String accessToken, MessageDto messageDto){
+        notificationClient.sendEmail(accessToken, successEmailTemplateName, messageDto);
     }
 
-    public void sendFailureEmail(MessageDto messageDto){
-        notificationClient.sendEmail(failureEmailTemplateName, messageDto);
+    public void sendFailureEmail(String accessToken, MessageDto messageDto){
+        notificationClient.sendEmail(accessToken, failureEmailTemplateName, messageDto);
     }
 
 }

--- a/src/main/java/uk/gov/cshr/report/service/OAuthService.java
+++ b/src/main/java/uk/gov/cshr/report/service/OAuthService.java
@@ -1,0 +1,26 @@
+package uk.gov.cshr.report.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.cshr.report.client.identity.oauth.IOAuthClient;
+
+@Service
+@Slf4j
+public class OAuthService {
+    @Value("${oauth.clientId}")
+    private String basicAuthClientId;
+
+    @Value("${oauth.clientSecret}")
+    private String basicAuthClientSecret;
+
+    private IOAuthClient oauthClient;
+
+    public OAuthService(IOAuthClient oauthClient) {
+        this.oauthClient = oauthClient;
+    }
+
+    public String getAccessToken(){
+        return oauthClient.getAccessToken(basicAuthClientId, basicAuthClientSecret);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -100,6 +100,12 @@ courseCompletions:
     jobCron: ${REPORT_REQUESTS_JOB_CRON:0 0 * * * *}
     defaultTimezone: "${COURSE_COMPLETION_REPORTS_DEFAULT_TIMEZONE:Europe/London}"
 
+notification:
+  serviceUrl: ${NOTIFICATION_SERVICE_URL:http://localhost:9006}
+  sendEmailEndpointTemplate: "${notification.serviceUrl}/notifications/emails/{{TEMPLATE_NAME}}/send"
+  successEmailTemplateName: ${COURSE_COMPLETIONS_REPORT_SUCCESS_EMAIL_NAME:COURSE_COMPLETIONS_REPORT_SUCCESS}
+  failureEmailTemplateName: ${COURSE_COMPLETIONS_REPORT_FAILURE_EMAIL_NAME:COURSE_COMPLETIONS_REPORT_FAILURE}
+
 
 info:
   name: "Report service API"

--- a/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsReportRequestIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsReportRequestIntegrationTest.java
@@ -8,6 +8,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,23 +22,25 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.containers.GenericContainer;
 import uk.gov.cshr.report.configuration.TestConfig;
 import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
+import uk.gov.cshr.report.dto.MessageDto;
 import uk.gov.cshr.report.repository.CourseCompletionReportRequestRepository;
+import uk.gov.cshr.report.service.NotificationService;
 import uk.gov.cshr.report.service.Scheduler;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
+import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import static junit.framework.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @AutoConfigureWebTestClient
 @Import(TestConfig.class)
+@ExtendWith(MockitoExtension.class)
 public class CourseCompletionsReportRequestIntegrationTest extends IntegrationTestBase{
     private static String directory = "temp-courseCompletionsJob";
     private String zipFileName = "course_completions_1_from_01_01_2024_to_01_02_2024.zip";
@@ -44,10 +50,14 @@ public class CourseCompletionsReportRequestIntegrationTest extends IntegrationTe
     private JdbcTemplate jdbcTemplate = new JdbcTemplate(new PGSimpleDataSource());
 
     @Autowired
-    Scheduler scheduler;
+    private CourseCompletionReportRequestRepository courseCompletionReportRequestRepository;
 
     @Autowired
-    CourseCompletionReportRequestRepository courseCompletionReportRequestRepository;
+    @InjectMocks
+    private Scheduler scheduler;
+
+    @Mock
+    private NotificationService notificationService;
 
     @Value("${spring.cloud.azure.storage.blob.connection-string}")
     private String azureBlobStorageConnectionString;
@@ -84,7 +94,6 @@ public class CourseCompletionsReportRequestIntegrationTest extends IntegrationTe
 
     @Test
     public void testReportRequestsSchedulerProcessesJobCorrectlyWhenNoExceptionIsThrown() throws IOException {
-
         jdbcTemplate.execute("""
         INSERT INTO course_completion_report_requests
             (report_request_id, requester_id, requester_email, requested_timestamp, completed_timestamp, status, from_date, to_date, course_ids, organisation_ids)
@@ -98,6 +107,7 @@ public class CourseCompletionsReportRequestIntegrationTest extends IntegrationTe
         testSchedulerStoresZipFileInAzureBlogStorageWithCorrectName();
         testSchedulerSetsProcessedCourseCompletionReportRequestStatusToSuccess();
         testZipFileContainsCsvFile();
+        testSchedulerCallsSendSuccessEmail();
     }
 
     private void testSchedulerCreatesAzureBlogStorageContainerForCourseCompletionReportRequests(){
@@ -155,17 +165,32 @@ public class CourseCompletionsReportRequestIntegrationTest extends IntegrationTe
         assertEquals(csvFileName, fileNames.get(0));
     }
 
+    private void testSchedulerCallsSendSuccessEmail(){
+        verify(notificationService).sendSuccessEmail(any(MessageDto.class));
+    }
+
     @Test
     public void testSchedulerSetsStatusOfReportRequestToFailedWhenJobFailsToComplete(){
+
         jdbcTemplate.execute("""
         INSERT INTO course_completion_report_requests
             (report_request_id, requester_id, requester_email, requested_timestamp, completed_timestamp, status, from_date, to_date, course_ids, organisation_ids)
             VALUES(1, 'RequesterA', 'RequesterA@domain.com', '2024-07-08 09:15:27.352', NULL, 'REQUESTED', '2024-01-01 00:00:00.000', '2024-02-01 00:00:00.000', '{c1,c2}', '{1}');
         """);
 
-        scheduler.processFailure(new Exception(), 1L);
+        scheduler.processFailure(new Exception(), 1L, "RequesterA@domain.com");
 
+        // Tests:
+        testSchedulerSetsProcessedCourseCompletionReportRequestStatusToFailed();
+        testSchedulerCallsSendFailureEmail();
+    }
+
+    private void testSchedulerSetsProcessedCourseCompletionReportRequestStatusToFailed(){
         List<CourseCompletionReportRequest> failedRequests = courseCompletionReportRequestRepository.findByStatus("FAILED");
         assertEquals(1, failedRequests.size());
+    }
+
+    private void testSchedulerCallsSendFailureEmail(){
+        verify(notificationService).sendFailureEmail(any(MessageDto.class));
     }
 }


### PR DESCRIPTION
This update sends success and failure emails to the course completion report requesters.

Changes:

* Update `HttpClient` to include `executeRequest()` a method for more flexible response classes
* Creates a new client for notification-service
* Adds a `sendEmail()` method to the notification client
* Creates a new `NotificationService` class
* Adds 2 new methods to the service: `sendSuccessEmail()` and `sendFailureEmail()`
* Adds implementations of `sendSuccessEmail()` and `sendFailureEmail()` from `NotificationService` to the Scheduler.
* Creates a new OAuth client for retrieving access tokens for use by the notification client