### PR TITLE
Idt feature lc 2722 request report

### DIFF
--- a/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
+++ b/src/main/java/uk/gov/cshr/report/controller/CourseCompletionsController.java
@@ -56,7 +56,7 @@ public class CourseCompletionsController {
 
     @GetMapping("/report-requests")
     @ResponseBody
-    public GetCourseCompletionReportRequestsResponse getAllReportRequests(@RequestBody @Valid GetCourseCompletionsReportRequestParams params){
+    public GetCourseCompletionReportRequestsResponse getAllReportRequests(@Valid GetCourseCompletionsReportRequestParams params){
         List<CourseCompletionReportRequest> reportRequests = courseCompletionReportRequestService.findReportRequestsByUserIdAndStatus(params);
         return new GetCourseCompletionReportRequestsResponse(reportRequests);
     }

--- a/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
+++ b/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
@@ -20,7 +20,7 @@ public class PostCourseCompletionsReportRequestsParamsToReportRequestMapper {
         reportRequest.setOrganisationIds(params.getOrganisationIds());
         reportRequest.setProfessionIds(params.getProfessionIds());
         reportRequest.setGradeIds(params.getGradeIds());
-        reportRequest.setRequesterTimezone(params.getRequesterTimezone());
+        reportRequest.setRequesterTimezone(params.getTimezone());
 
         return reportRequest;
     }

--- a/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
+++ b/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
@@ -14,8 +14,8 @@ public class PostCourseCompletionsReportRequestsParamsToReportRequestMapper {
         reportRequest.setRequesterEmail(params.getUserEmail());
         reportRequest.setStatus("REQUESTED");
         reportRequest.setRequestedTimestamp(ZonedDateTime.now().withZoneSameInstant(ZoneId.of("UTC")));
-        reportRequest.setFromDate(params.getStartDate().atStartOfDay(ZoneOffset.UTC));
-        reportRequest.setToDate(params.getEndDate().atStartOfDay(ZoneOffset.UTC));
+        reportRequest.setFromDate(params.getStartDate().atZone(ZoneOffset.UTC));
+        reportRequest.setToDate(params.getEndDate().atZone(ZoneOffset.UTC));
         reportRequest.setCourseIds(params.getCourseIds());
         reportRequest.setOrganisationIds(params.getOrganisationIds());
         reportRequest.setProfessionIds(params.getProfessionIds());

--- a/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsReportRequestParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsReportRequestParams.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -13,5 +15,5 @@ public class GetCourseCompletionsReportRequestParams {
     private String userId;
 
     @NotNull
-    private String status;
+    private List<String> status;
 }

--- a/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -20,12 +20,12 @@ public class PostCourseCompletionsReportRequestParams {
     private String userEmail;
 
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private LocalDate startDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startDate;
 
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private LocalDate endDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endDate;
 
     @NotNull
     private List<String> courseIds;
@@ -36,5 +36,10 @@ public class PostCourseCompletionsReportRequestParams {
 
     private List<Integer> gradeIds;
 
-    private String requesterTimezone;
+    @NotNull
+    private String timezone;
+
+    public String getRequesterTimezone() {
+        return this.timezone;
+    }
 }

--- a/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
@@ -39,7 +39,4 @@ public class PostCourseCompletionsReportRequestParams {
     @NotNull
     private String timezone;
 
-    public String getRequesterTimezone() {
-        return this.timezone;
-    }
 }

--- a/src/main/java/uk/gov/cshr/report/repository/CourseCompletionEventRepository.java
+++ b/src/main/java/uk/gov/cshr/report/repository/CourseCompletionEventRepository.java
@@ -32,7 +32,7 @@ public interface CourseCompletionEventRepository extends JpaRepository<CourseCom
                                                                         @Param("professionIds") List<Integer> professionIds);
 
     @Query("""
-        select cce 
+        select cce
         from CourseCompletionEvent cce
         where cce.eventTimestamp >= :fromDate and cce.eventTimestamp <= :toDate
         and cce.courseId in :courseIds

--- a/src/main/java/uk/gov/cshr/report/repository/CourseCompletionReportRequestRepository.java
+++ b/src/main/java/uk/gov/cshr/report/repository/CourseCompletionReportRequestRepository.java
@@ -6,7 +6,7 @@ import uk.gov.cshr.report.domain.CourseCompletionReportRequest;
 import java.util.List;
 
 public interface CourseCompletionReportRequestRepository extends JpaRepository<CourseCompletionReportRequest, Long> {
-    List<CourseCompletionReportRequest> findByRequesterIdAndStatus(String requestedId, String status);
+    List<CourseCompletionReportRequest> findByRequesterIdAndStatusIn(String requestedId, List<String> status);
     CourseCompletionReportRequest findByReportRequestId(Long reportRequestId);
     List<CourseCompletionReportRequest> findByStatus(String status);
 }

--- a/src/main/java/uk/gov/cshr/report/service/CourseCompletionReportRequestService.java
+++ b/src/main/java/uk/gov/cshr/report/service/CourseCompletionReportRequestService.java
@@ -27,7 +27,7 @@ public class CourseCompletionReportRequestService {
     }
 
     public List<CourseCompletionReportRequest> findReportRequestsByUserIdAndStatus(GetCourseCompletionsReportRequestParams params){
-        return courseCompletionReportRequestRepository.findByRequesterIdAndStatus(params.getUserId(), params.getStatus());
+        return courseCompletionReportRequestRepository.findByRequesterIdAndStatusIn(params.getUserId(), params.getStatus());
     }
 
     public void setStatusForReportRequest(Long reportRequestId, CourseCompletionReportRequestStatus status){
@@ -47,7 +47,7 @@ public class CourseCompletionReportRequestService {
     }
 
     public boolean userReachedMaxReportRequests(String userId){
-        GetCourseCompletionsReportRequestParams params = new GetCourseCompletionsReportRequestParams(userId, "REQUESTED");
+        GetCourseCompletionsReportRequestParams params = new GetCourseCompletionsReportRequestParams(userId, List.of("REQUESTED"));
         List<CourseCompletionReportRequest> pendingRequests = findReportRequestsByUserIdAndStatus(params);
         return pendingRequests.size() >= maxRequestsPerUser;
     }

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -55,7 +55,8 @@ public class CourseCompletionsControllerTest {
     @Test
     @WithMockUser(username = "user")
     public void testPostReportRequestsEndpointReturnsOkWhenRequestBodyIsCorrect() throws Exception {
-        String requestBody = "{\"userId\": \"user003\", \"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01T00:00:00\", \"endDate\": \"2024-02-01T00:00:00\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8]}";
+        String requestBody = "{\"userId\": \"user003\", \"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01T00:00:00\", \"endDate\": \"2024-02-01T00:00:00\"," +
+                "\"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8], \"timezone\": \"+1\"}";
 
         mockMvc.perform(
                 post("/course-completions/report-requests")

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -116,14 +116,9 @@ public class CourseCompletionsControllerTest {
     @Test
     @WithMockUser(username = "user")
     public void testGetReportRequestsEndpointReturnsOkIfCorrectRequestBodyIsGiven() throws Exception {
-        String requestBody = "{\n" +
-                "    \"userId\": \"user003\",\n" +
-                "    \"status\": \"REQUESTED\"\n" +
-                "}";
         mockMvc.perform(
-                        get("/course-completions/report-requests")
+                        get("/course-completions/report-requests?userId=user003&status=REQUESTED")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(requestBody)
                                 .with(csrf())
                                 .accept(MediaType.APPLICATION_JSON)
                                 .characterEncoding("utf-8"))

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -55,7 +55,7 @@ public class CourseCompletionsControllerTest {
     @Test
     @WithMockUser(username = "user")
     public void testPostReportRequestsEndpointReturnsOkWhenRequestBodyIsCorrect() throws Exception {
-        String requestBody = "{\"userId\": \"user003\", \"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01\", \"endDate\": \"2024-02-01\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8]}";
+        String requestBody = "{\"userId\": \"user003\", \"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01T00:00:00\", \"endDate\": \"2024-02-01T00:00:00\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8]}";
 
         mockMvc.perform(
                 post("/course-completions/report-requests")
@@ -71,7 +71,7 @@ public class CourseCompletionsControllerTest {
     @Test
     @WithMockUser(username = "user")
     public void testPostReportRequestsEndpointReturnsOkWhenRequestBodyIsCorrectWithTimezone() throws Exception {
-        String requestBody = "{\"userId\": \"user003\", \"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01\", \"endDate\": \"2024-02-01\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8], \"requesterTimezone\": \"Europe/London\"}";
+        String requestBody = "{\"userId\": \"user003\", \"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01T00:00:00\", \"endDate\": \"2024-02-01T00:00:00\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8], \"requesterTimezone\": \"Europe/London\"}";
 
         mockMvc.perform(
                         post("/course-completions/report-requests")
@@ -87,7 +87,7 @@ public class CourseCompletionsControllerTest {
     @Test
     @WithMockUser(username = "user")
     public void testPostReportRequestsEndpointReturnsOkWhenRequestBodyIsMissingRequiredFields() throws Exception {
-        String requestBody = "{\"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01\", \"endDate\": \"2024-02-01\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8]}";
+        String requestBody = "{\"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01T00:00:00\", \"endDate\": \"2024-02-01T00:00:00\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8]}";
 
         mockMvc.perform(
                         post("/course-completions/report-requests")

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -72,7 +72,7 @@ public class CourseCompletionsControllerTest {
     @Test
     @WithMockUser(username = "user")
     public void testPostReportRequestsEndpointReturnsOkWhenRequestBodyIsCorrectWithTimezone() throws Exception {
-        String requestBody = "{\"userId\": \"user003\", \"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01T00:00:00\", \"endDate\": \"2024-02-01T00:00:00\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8], \"requesterTimezone\": \"Europe/London\"}";
+        String requestBody = "{\"userId\": \"user003\", \"userEmail\": \"learner3@domain.com\", \"startDate\": \"2024-01-01T00:00:00\", \"endDate\": \"2024-02-01T00:00:00\", \"courseIds\": [\"course1\", \"course2\"], \"organisationIds\": [1,2,3,4], \"professionIds\": [5,6,7,8], \"timezone\": \"Europe/London\"}";
 
         mockMvc.perform(
                         post("/course-completions/report-requests")

--- a/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
@@ -261,12 +261,13 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
         String requestBody = "{\n" +
                 "    \"userId\": \"testUser01\",\n" +
                 "    \"userEmail\": \"user01@domain.com\",\n" +
-                "    \"startDate\": \"2024-01-01\",\n" +
-                "    \"endDate\": \"2024-02-01\",\n" +
+                "    \"startDate\": \"2024-01-01T00:00:00\",\n" +
+                "    \"endDate\": \"2024-02-01T00:00:00\",\n" +
                 "    \"courseIds\": [\"course1\", \"course2\"],\n" +
                 "    \"organisationIds\": [1,2,3,4],\n" +
                 "    \"professionIds\": [5,6,7,8],\n" +
-                "    \"gradeIds\": [4,3,2]\n" +
+                "    \"gradeIds\": [4,3,2]\n," +
+                "    \"timezone\": \"+1\"\n" +
                 "}";
 
         String expectedResponseKey = "addedSuccessfully";
@@ -293,12 +294,13 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
         String requestBody = "{\n" +
                 "    \"userId\": \"testUser02\",\n" +
                 "    \"userEmail\": \"user02@domain.com\",\n" +
-                "    \"startDate\": \"2024-01-01\",\n" +
-                "    \"endDate\": \"2024-02-01\",\n" +
+                "    \"startDate\": \"2024-01-01T00:00:00\",\n" +
+                "    \"endDate\": \"2024-02-01T00:00:00\",\n" +
                 "    \"courseIds\": [\"course1\", \"course2\"],\n" +
                 "    \"organisationIds\": [1,2,3,4],\n" +
                 "    \"professionIds\": [5,6,7,8],\n" +
-                "    \"gradeIds\": [4,3,2]\n" +
+                "    \"gradeIds\": [4,3,2],\n" +
+                "    \"timezone\": \"+1\"\n" +
                 "}";
 
         String expectedAddedSuccessfullyResponseKey = "addedSuccessfully";
@@ -338,12 +340,13 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
         String postRequestBody = "{\n" +
                 "    \"userId\": \"testUser03\",\n" +
                 "    \"userEmail\": \"user03@domain.com\",\n" +
-                "    \"startDate\": \"2024-01-01\",\n" +
-                "    \"endDate\": \"2024-02-01\",\n" +
+                "    \"startDate\": \"2024-01-01T00:00:00\",\n" +
+                "    \"endDate\": \"2024-02-01T00:00:00\",\n" +
                 "    \"courseIds\": [\"course1\", \"course2\"],\n" +
                 "    \"organisationIds\": [1,2,3,4],\n" +
                 "    \"professionIds\": [5,6,7,8],\n" +
-                "    \"gradeIds\": [4,3,2]\n" +
+                "    \"gradeIds\": [4,3,2],\n" +
+                "    \"timezone\": \"+1\"\n" +
                 "}";
 
         webTestClient

--- a/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsIntegrationTest.java
@@ -346,11 +346,6 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
                 "    \"gradeIds\": [4,3,2]\n" +
                 "}";
 
-        String getRequestBody = "{\n" +
-                "    \"userId\": \"testUser03\",\n" +
-                "    \"status\": \"REQUESTED\"\n" +
-                "}";
-
         webTestClient
                 .post()
                 .uri(uriBuilder -> uriBuilder.path(reportRequestsEndpoint).build())
@@ -363,10 +358,11 @@ public class CourseCompletionsIntegrationTest extends IntegrationTestBase {
 
         webTestClient
                 .method(HttpMethod.GET)
-                .uri(uriBuilder -> uriBuilder.path(reportRequestsEndpoint).build())
+                .uri(uriBuilder -> uriBuilder.path(reportRequestsEndpoint)
+                        .queryParam("userId", "testUser03")
+                        .queryParam("status", "REQUESTED").build())
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(BodyInserters.fromObject(getRequestBody))
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()


### PR DESCRIPTION
- Use timestamps over dates when generating report requests
- Shift parameters to query in `GET` report requests endpoint
- Rename timezeone parameter to match csl-service