### PR TITLE
LC-3163 / LC-3164: Update emails

### DIFF
--- a/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
+++ b/src/main/java/uk/gov/cshr/report/controller/mappers/PostCourseCompletionsReportRequestsParamsToReportRequestMapper.java
@@ -21,6 +21,7 @@ public class PostCourseCompletionsReportRequestsParamsToReportRequestMapper {
         reportRequest.setProfessionIds(params.getProfessionIds());
         reportRequest.setGradeIds(params.getGradeIds());
         reportRequest.setRequesterTimezone(params.getTimezone());
+        reportRequest.setFullName(params.getFullName());
 
         return reportRequest;
     }

--- a/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/PostCourseCompletionsReportRequestParams.java
@@ -39,4 +39,6 @@ public class PostCourseCompletionsReportRequestParams {
     @NotNull
     private String timezone;
 
+    private String fullName;
+
 }

--- a/src/main/java/uk/gov/cshr/report/domain/report/CourseCompletionReportRequest.java
+++ b/src/main/java/uk/gov/cshr/report/domain/report/CourseCompletionReportRequest.java
@@ -61,4 +61,7 @@ public class CourseCompletionReportRequest {
     @Column(name = "requester_timezone")
     private String requesterTimezone;
 
+    @Column(name = "requester_full_name")
+    private String fullName;
+
 }

--- a/src/main/java/uk/gov/cshr/report/service/Scheduler.java
+++ b/src/main/java/uk/gov/cshr/report/service/Scheduler.java
@@ -131,7 +131,7 @@ public class Scheduler {
         ZoneOffset targetZoneOffset = ZoneOffset.of(request.getRequesterTimezone());
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d MMMM yyyy HH:mm");
         String formattedDateTime = zonedDateTime.withZoneSameInstant(targetZoneOffset).format(formatter);
-        sendFailureEmail(request.getRequesterEmail(), formattedDateTime);
+        sendFailureEmail(request.getRequesterEmail(), request.getFullName(), formattedDateTime);
         log.debug(String.format("Failure email sent to %s", request.getRequesterEmail()));
     }
 
@@ -198,12 +198,12 @@ public class Scheduler {
         notificationService.sendSuccessEmail(messageDto);
     }
 
-    private void sendFailureEmail(String email, String time){
+    private void sendFailureEmail(String email, String requesterFullName, String time){
         MessageDto messageDto = new MessageDto();
         messageDto.setRecipient(email);
 
         Map<String, String> personalisation = new HashMap<>();
-        personalisation.put("userName", email);
+        personalisation.put("userName", requesterFullName);
         personalisation.put("exportDate", time);
         personalisation.put("reportType", "Course completions");
 

--- a/src/main/java/uk/gov/cshr/report/service/Scheduler.java
+++ b/src/main/java/uk/gov/cshr/report/service/Scheduler.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -72,10 +73,11 @@ public class Scheduler {
         for(CourseCompletionReportRequest request : requests) {
             log.info("Processing request {}", request.getRequesterId());
             try {
-                processRequest(request);
+                throw new Exception();
+//                processRequest(request);
             }
             catch (Exception e){
-                processFailure(e, request.getReportRequestId(), request.getRequesterEmail());
+                processFailure(e, request);
             }
             finally {
                 courseCompletionReportRequestService.setCompletedDateForReportRequest(request.getReportRequestId(), ZonedDateTime.now().withZoneSameInstant(ZoneId.of("UTC")));
@@ -112,18 +114,26 @@ public class Scheduler {
         courseCompletionReportRequestService.setStatusForReportRequest(request.getReportRequestId(), CourseCompletionReportRequestStatus.SUCCESS);
 
         log.info(String.format("Sending success email to %s", request.getRequesterEmail()));
-        sendSuccessEmail(request.getRequesterEmail(), uploadResult.getDownloadUrl());
+        ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        ZoneOffset targetZoneOffset = ZoneOffset.of(request.getRequesterTimezone());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d MMMM yyyy HH:mm");
+        String formattedDateTime = zonedDateTime.withZoneSameInstant(targetZoneOffset).format(formatter);
+        sendSuccessEmail(request.getRequesterEmail(), uploadResult.getDownloadUrl(), formattedDateTime);
         log.info(String.format("Success email sent to %s", request.getRequesterEmail()));
     }
 
-    public void processFailure(Exception e, Long requestId, String requesterEmail){
-        log.info(String.format("Processing request %s has failed", requestId), e);
+    public void processFailure(Exception e, CourseCompletionReportRequest request){
+        log.info(String.format("Processing request %s has failed", request.getReportRequestId()), e);
 
-        courseCompletionReportRequestService.setStatusForReportRequest(requestId, CourseCompletionReportRequestStatus.FAILED);
+        courseCompletionReportRequestService.setStatusForReportRequest(request.getReportRequestId(), CourseCompletionReportRequestStatus.FAILED);
 
-        log.debug(String.format("Sending failure email to %s", requesterEmail));
-        sendFailureEmail(requesterEmail);
-        log.debug(String.format("Failure email sent to %s", requesterEmail));
+        log.debug(String.format("Sending failure email to %s", request.getRequesterEmail()));
+        ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        ZoneOffset targetZoneOffset = ZoneOffset.of(request.getRequesterTimezone());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d MMMM yyyy HH:mm");
+        String formattedDateTime = zonedDateTime.withZoneSameInstant(targetZoneOffset).format(formatter);
+        sendFailureEmail(request.getRequesterEmail(), formattedDateTime);
+        log.debug(String.format("Failure email sent to %s", request.getRequesterEmail()));
     }
 
     private List<CourseCompletionEvent> getCourseCompletionsForRequest(CourseCompletionReportRequest request){
@@ -175,18 +185,30 @@ public class Scheduler {
         return String.format("course_completions_%s_from_%s_to_%s", requestId, fromDate.format(formatter), toDate.format(formatter));
     }
 
-    private void sendSuccessEmail(String email, String blobUrl){
+    private void sendSuccessEmail(String email, String blobUrl, String time){
         MessageDto messageDto = new MessageDto();
         messageDto.setRecipient(email);
+
         Map<String, String> personalisation = new HashMap<>();
+        personalisation.put("userName", email);
+        personalisation.put("exportDate", time);
         personalisation.put("reportUrl", blobUrl);
+        personalisation.put("reportType", "Course completions");
+
         messageDto.setPersonalisation(personalisation);
         notificationService.sendSuccessEmail(messageDto);
     }
 
-    private void sendFailureEmail(String email){
+    private void sendFailureEmail(String email, String time){
         MessageDto messageDto = new MessageDto();
         messageDto.setRecipient(email);
+
+        Map<String, String> personalisation = new HashMap<>();
+        personalisation.put("userName", email);
+        personalisation.put("exportDate", time);
+        personalisation.put("reportType", "Course completions");
+
+        messageDto.setPersonalisation(personalisation);
         notificationService.sendFailureEmail(messageDto);
     }
 

--- a/src/main/java/uk/gov/cshr/report/service/Scheduler.java
+++ b/src/main/java/uk/gov/cshr/report/service/Scheduler.java
@@ -73,8 +73,7 @@ public class Scheduler {
         for(CourseCompletionReportRequest request : requests) {
             log.info("Processing request {}", request.getRequesterId());
             try {
-                throw new Exception();
-//                processRequest(request);
+                processRequest(request);
             }
             catch (Exception e){
                 processFailure(e, request);

--- a/src/main/java/uk/gov/cshr/report/service/Scheduler.java
+++ b/src/main/java/uk/gov/cshr/report/service/Scheduler.java
@@ -117,7 +117,7 @@ public class Scheduler {
         ZoneOffset targetZoneOffset = ZoneOffset.of(request.getRequesterTimezone());
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d MMMM yyyy HH:mm");
         String formattedDateTime = zonedDateTime.withZoneSameInstant(targetZoneOffset).format(formatter);
-        sendSuccessEmail(request.getRequesterEmail(), uploadResult.getDownloadUrl(), formattedDateTime);
+        sendSuccessEmail(request.getRequesterEmail(), request.getFullName(), uploadResult.getDownloadUrl(), formattedDateTime);
         log.info(String.format("Success email sent to %s", request.getRequesterEmail()));
     }
 
@@ -184,12 +184,12 @@ public class Scheduler {
         return String.format("course_completions_%s_from_%s_to_%s", requestId, fromDate.format(formatter), toDate.format(formatter));
     }
 
-    private void sendSuccessEmail(String email, String blobUrl, String time){
+    private void sendSuccessEmail(String email, String requesterFullName, String blobUrl, String time){
         MessageDto messageDto = new MessageDto();
         messageDto.setRecipient(email);
 
         Map<String, String> personalisation = new HashMap<>();
-        personalisation.put("userName", email);
+        personalisation.put("userName", requesterFullName);
         personalisation.put("exportDate", time);
         personalisation.put("reportUrl", blobUrl);
         personalisation.put("reportType", "Course completions");

--- a/src/main/resources/db/migration/postgresql/V2.5__add-full-name-column.sql
+++ b/src/main/resources/db/migration/postgresql/V2.5__add-full-name-column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE course_completion_report_requests
+    ADD COLUMN requester_full_name VARCHAR(255);

--- a/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsReportRequestIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsReportRequestIntegrationTest.java
@@ -177,7 +177,7 @@ public class CourseCompletionsReportRequestIntegrationTest extends IntegrationTe
         jdbcTemplate.execute("""
         INSERT INTO course_completion_report_requests
             (report_request_id, requester_id, requester_email, requested_timestamp, completed_timestamp, status, from_date, to_date, course_ids, organisation_ids, requester_timezone, requester_full_name)
-            VALUES(1, 'RequesterA', 'RequesterA@domain.com', '2024-07-08 09:15:27.352', NULL, 'REQUESTED', '2024-01-01 00:00:00.000', '2024-02-01 00:00:00.000', '{c1,c2}', '{1}', '+01:00', "Requester A");
+            VALUES(1, 'RequesterA', 'RequesterA@domain.com', '2024-07-08 09:15:27.352', NULL, 'REQUESTED', '2024-01-01 00:00:00.000', '2024-02-01 00:00:00.000', '{c1,c2}', '{1}', '+01:00', 'Requester A');
         """);
 
         CourseCompletionReportRequest courseCompletionReportRequest = new CourseCompletionReportRequest();

--- a/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsReportRequestIntegrationTest.java
+++ b/src/test/java/uk/gov/cshr/report/integration/CourseCompletionsReportRequestIntegrationTest.java
@@ -99,8 +99,8 @@ public class CourseCompletionsReportRequestIntegrationTest extends IntegrationTe
     public void testReportRequestsSchedulerProcessesJobCorrectlyWhenNoExceptionIsThrown() throws IOException {
         jdbcTemplate.execute("""
         INSERT INTO course_completion_report_requests
-            (report_request_id, requester_id, requester_email, requested_timestamp, completed_timestamp, status, from_date, to_date, course_ids, organisation_ids)
-            VALUES(1, 'RequesterA', 'RequesterA@domain.com', '2024-07-08 09:15:27.352', NULL, 'REQUESTED', '2024-01-01 00:00:00.000', '2024-02-01 00:00:00.000', '{c1,c2}', '{1}');
+            (report_request_id, requester_id, requester_email, requested_timestamp, completed_timestamp, status, from_date, to_date, course_ids, organisation_ids, requester_timezone, requester_full_name)
+            VALUES(1, 'RequesterA', 'RequesterA@domain.com', '2024-07-08 09:15:27.352', NULL, 'REQUESTED', '2024-01-01 00:00:00.000', '2024-02-01 00:00:00.000', '{c1,c2}', '{1}', '+01:00', 'Requester A');
         """);
         scheduler.generateReportsForCourseCompletionRequests();
 
@@ -176,11 +176,16 @@ public class CourseCompletionsReportRequestIntegrationTest extends IntegrationTe
 
         jdbcTemplate.execute("""
         INSERT INTO course_completion_report_requests
-            (report_request_id, requester_id, requester_email, requested_timestamp, completed_timestamp, status, from_date, to_date, course_ids, organisation_ids)
-            VALUES(1, 'RequesterA', 'RequesterA@domain.com', '2024-07-08 09:15:27.352', NULL, 'REQUESTED', '2024-01-01 00:00:00.000', '2024-02-01 00:00:00.000', '{c1,c2}', '{1}');
+            (report_request_id, requester_id, requester_email, requested_timestamp, completed_timestamp, status, from_date, to_date, course_ids, organisation_ids, requester_timezone, requester_full_name)
+            VALUES(1, 'RequesterA', 'RequesterA@domain.com', '2024-07-08 09:15:27.352', NULL, 'REQUESTED', '2024-01-01 00:00:00.000', '2024-02-01 00:00:00.000', '{c1,c2}', '{1}', '+01:00', "Requester A");
         """);
 
-        scheduler.processFailure(new Exception(), 1L, "RequesterA@domain.com");
+        CourseCompletionReportRequest courseCompletionReportRequest = new CourseCompletionReportRequest();
+        courseCompletionReportRequest.setReportRequestId(1L);
+        courseCompletionReportRequest.setRequesterEmail("RequesterA@domain.com");
+        courseCompletionReportRequest.setRequesterTimezone("+01:00");
+        courseCompletionReportRequest.setFullName("Requester A");
+        scheduler.processFailure(new Exception(), courseCompletionReportRequest);
 
         // Tests:
         testSchedulerSetsProcessedCourseCompletionReportRequestStatusToFailed();


### PR DESCRIPTION
This change: 

* Updates the endpoint to create new course completion report requests to expect a `fullName` parameter.
* Creates a new Flyway script to create a new `requester_full_name` column in `course_completion_report_requests`.
* Updates the endpoint to add the `fullName` value to the new column
* Updates the Scheduler to send success and failure emails according to the new email templates.