### PR TITLE
LC-3553: Create registered learners tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out
 .settings/*
 target/
 data/
+.DS_Store

--- a/src/main/resources/db/migration/postgresql/V2.9__create-registered-learners-table.sql
+++ b/src/main/resources/db/migration/postgresql/V2.9__create-registered-learners-table.sql
@@ -13,6 +13,9 @@ CREATE TABLE registered_learners(
     updated_timestamp TIMESTAMPTZ NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_organisation_id_registered_learners
+    ON registered_learners (organisation_id);
+
 CREATE TABLE registered_learners_report_requests (
     report_request_id SERIAL4 PRIMARY KEY,
     requester_id VARCHAR(36) NOT NULL,

--- a/src/main/resources/db/migration/postgresql/V2.9__create-registered-learners-table.sql
+++ b/src/main/resources/db/migration/postgresql/V2.9__create-registered-learners-table.sql
@@ -1,0 +1,33 @@
+CREATE TABLE registered_learners(
+    uid CHAR(36) PRIMARY KEY,
+    email VARCHAR(150) NOT NULL,
+    active BOOLEAN NOT NULL,
+    full_name VARCHAR(255) NOT NULL,
+    organisation_id INT4,
+    organisation_name TEXT,
+    grade_id INT4,
+    grade_name VARCHAR(255),
+    profession_id INT4,
+    profession_name VARCHAR(255),
+    created_timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_timestamp TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE registered_learners_report_requests (
+    report_request_id SERIAL4 PRIMARY KEY,
+    requester_id VARCHAR(36) NOT NULL,
+    requester_email VARCHAR(150) NOT NULL,
+    requester_full_name VARCHAR(255) NOT NULL,
+    organisation_ids INT[],
+    status VARCHAR(20) NOT NULL DEFAULT 'REQUESTED',
+    url_slug VARCHAR(20) NOT NULL DEFAULT substr(md5(random()::text), 1, 20) UNIQUE,
+    download_base_url VARCHAR(255) NOT NULL DEFAULT 'NULL',
+    times_downloaded INT4 NOT NULL DEFAULT 0,
+    requested_timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_timestamp TIMESTAMPTZ,
+    last_downloaded_timestamp TIMESTAMPTZ,
+
+    CONSTRAINT status_fk
+        FOREIGN KEY(status)
+            REFERENCES report_requests_status(status)
+);

--- a/src/main/resources/db/migration/postgresql/V2.9__create-registered-learners-table.sql
+++ b/src/main/resources/db/migration/postgresql/V2.9__create-registered-learners-table.sql
@@ -19,7 +19,7 @@ CREATE TABLE registered_learners_report_requests (
     requester_email VARCHAR(150) NOT NULL,
     requester_full_name VARCHAR(255) NOT NULL,
     organisation_ids INT[],
-    status VARCHAR(20) NOT NULL DEFAULT 'REQUESTED',
+    status VARCHAR(20) NOT NULL,
     url_slug VARCHAR(20) NOT NULL DEFAULT substr(md5(random()::text), 1, 20) UNIQUE,
     download_base_url VARCHAR(255) NOT NULL DEFAULT 'NULL',
     times_downloaded INT4 NOT NULL DEFAULT 0,


### PR DESCRIPTION
This change creates a new Flyway script which creates 2 new tables: `registered_learners` and `registered_learners_report_requests `