### PR TITLE
LC-3765 remove minimum orgs

### DIFF
--- a/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
@@ -27,7 +27,7 @@ public class GetCourseCompletionsParams {
 
     private ZoneId timezone = ZoneId.of("UTC");
 
-    @Size(min = 1, max = 400)
+    @Size(max = 400)
     private List<Integer> organisationIds;
 
     private List<Integer> professionIds;

--- a/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
+++ b/src/main/java/uk/gov/cshr/report/controller/model/GetCourseCompletionsParams.java
@@ -36,4 +36,12 @@ public class GetCourseCompletionsParams {
 
     private AggregationBinDelimiter binDelimiter = AggregationBinDelimiter.DAY;
 
+    public List<Integer> getOrganisationIds() {
+        if (this.organisationIds == null || this.organisationIds.isEmpty()) {
+            return null;
+        } else {
+            return organisationIds;
+        }
+    }
+
 }

--- a/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
+++ b/src/test/java/uk/gov/cshr/report/controller/CourseCompletionsControllerTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -69,8 +68,7 @@ public class CourseCompletionsControllerTest {
                         .characterEncoding("utf-8"))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(content().string(containsString("Field courseIds is invalid: size must be between 1 and 30")))
-                .andExpect(content().string(containsString("Field organisationIds is invalid: size must be between 1 and 400")));
+                .andExpect(content().string(containsString("Field courseIds is invalid: size must be between 1 and 30")));
     }
 
     @Test


### PR DESCRIPTION
- Remove minimum organisation ID requirement for querying by 'All learning'
- Force null on organisation IDs when the list is empty