### PR TITLE
LC-4365 POST for civil servant UID map

### DIFF
--- a/src/main/java/uk/gov/cshr/report/client/civilServantRegistry/CivilServantRegistryClient.java
+++ b/src/main/java/uk/gov/cshr/report/client/civilServantRegistry/CivilServantRegistryClient.java
@@ -7,6 +7,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
 import uk.gov.cshr.report.client.IHttpClient;
 import uk.gov.cshr.report.domain.registry.CivilServant;
+import uk.gov.cshr.report.domain.registry.GetCivilServantsForUidsParams;
 import uk.gov.cshr.report.service.ParameterizedTypeReferenceFactory;
 
 import java.util.Collection;
@@ -48,11 +49,8 @@ public class CivilServantRegistryClient implements ICivilServantRegistryClient{
     public Map<String, CivilServant> getCivilServantMapForLearnerIds(Collection<String> learnerUids, Integer organisationId) {
         Map<String, CivilServant> map = new HashMap<>();
         batchList(maxUidsSize, learnerUids).forEach(batch -> {
-            String url = String.format("%s?uids=%s", civilServantsForUidsUrl, String.join(",", learnerUids));
-            if (organisationId != null) {
-                url += "&organisationId=" + organisationId;
-            }
-            RequestEntity<Void> request = RequestEntity.get(url).build();
+            GetCivilServantsForUidsParams params = new GetCivilServantsForUidsParams(learnerUids, organisationId);
+            RequestEntity<GetCivilServantsForUidsParams> request = RequestEntity.post(civilServantsForUidsUrl).body(params);
             Map<String, CivilServant> response = httpClient.executeMapRequest(request, parameterizedTypeReferenceFactory.createMapReference(CivilServant.class));
             if (response != null) {
                 map.putAll(response);

--- a/src/main/java/uk/gov/cshr/report/domain/registry/GetCivilServantsForUidsParams.java
+++ b/src/main/java/uk/gov/cshr/report/domain/registry/GetCivilServantsForUidsParams.java
@@ -1,0 +1,19 @@
+package uk.gov.cshr.report.domain.registry;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Collection;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetCivilServantsForUidsParams {
+
+    private Collection<String> uids;
+    private Integer organisationId = null;
+
+}


### PR DESCRIPTION
- Use a POST to get the civil servant map rather than a get to avoid URL size limits